### PR TITLE
Removing the redundant force_on attribute of OnOffParameters.

### DIFF
--- a/flixOpt/components.py
+++ b/flixOpt/components.py
@@ -305,9 +305,7 @@ class TransmissionModel(ComponentModel):
         if (self.element.absolute_losses is not None) and np.any(self.element.absolute_losses.active_data != 0):
             for flow in self.element.inputs + self.element.outputs:
                 if flow.on_off_parameters is None:
-                    flow.on_off_parameters = OnOffParameters(force_on=True)
-                else:
-                    flow.on_off_parameters.force_on = True
+                    flow.on_off_parameters = OnOffParameters()
 
         # Make sure either None or both in Flows have InvestParameters
         if self.element.in2 is not None:

--- a/flixOpt/elements.py
+++ b/flixOpt/elements.py
@@ -440,16 +440,12 @@ class ComponentModel(ElementModel):
         if self.element.on_off_parameters:
             for flow in all_flows:
                 if flow.on_off_parameters is None:
-                    flow.on_off_parameters = OnOffParameters(force_on=True)
-                else:
-                    flow.on_off_parameters.force_on = True
+                    flow.on_off_parameters = OnOffParameters()
 
         if self.element.prevent_simultaneous_flows:
             for flow in self.element.prevent_simultaneous_flows:
                 if flow.on_off_parameters is None:
-                    flow.on_off_parameters = OnOffParameters(force_on=True)
-                else:
-                    flow.on_off_parameters.force_on = True
+                    flow.on_off_parameters = OnOffParameters()
 
         self.sub_models.extend([flow.create_model() for flow in all_flows])
         for sub_model in self.sub_models:

--- a/flixOpt/features.py
+++ b/flixOpt/features.py
@@ -24,7 +24,8 @@ logger = logging.getLogger('flixOpt')
 
 class InvestmentModel(ElementModel):
     """Class for modeling an investment"""
-    def __init__(self, element: Union['Flow', 'Storage'],
+    def __init__(self,
+                 element: Union['Flow', 'Storage'],
                  invest_parameters: InvestParameters,
                  defining_variable: [VariableTS],
                  relative_bounds_of_defining_variable: Tuple[Numeric, Numeric],
@@ -160,7 +161,8 @@ class OnOffModel(ElementModel):
     Class for modeling the on and off state of a variable
     If defining_bounds are given, creates sufficient lower bounds
     """
-    def __init__(self, element: Element,
+    def __init__(self,
+                 element: Element,
                  on_off_parameters: OnOffParameters,
                  defining_variables: List[VariableTS],
                  defining_bounds: List[Tuple[Numeric, Numeric]],
@@ -188,17 +190,17 @@ class OnOffModel(ElementModel):
         assert len(defining_variables) == len(defining_bounds), f'Every defining Variable needs bounds to Model OnOff'
 
     def do_modeling(self, system_model: SystemModel):
-        if self._on_off_parameters.use_on:
-            self.on = create_variable('on', self, system_model.nr_of_time_steps, is_binary=True,
-                                      previous_values=self._previous_on_values(Config.EPSILON))
-            self.total_on_hours = create_variable('totalOnHours', self, 1,
-                                                  lower_bound=self._on_off_parameters.on_hours_total_min,
-                                                  upper_bound=self._on_off_parameters.on_hours_total_max)
-            eq_total_on = create_equation('totalOnHours', self)
-            eq_total_on.add_summand(self.on, system_model.dt_in_hours, as_sum=True)
-            eq_total_on.add_summand(self.total_on_hours, -1)
+        self.on = create_variable('on', self, system_model.nr_of_time_steps, is_binary=True,
+                                  previous_values=self._previous_on_values(Config.EPSILON))
 
-            self._add_on_constraints(system_model, system_model.indices)
+        self.total_on_hours = create_variable('totalOnHours', self, 1,
+                                              lower_bound=self._on_off_parameters.on_hours_total_min,
+                                              upper_bound=self._on_off_parameters.on_hours_total_max)
+        eq_total_on = create_equation('totalOnHours', self)
+        eq_total_on.add_summand(self.on, system_model.dt_in_hours, as_sum=True)
+        eq_total_on.add_summand(self.total_on_hours, -1)
+
+        self._add_on_constraints(system_model, system_model.indices)
 
         if self._on_off_parameters.use_off:
             self.off = create_variable('off', self, system_model.nr_of_time_steps, is_binary=True,
@@ -211,13 +213,13 @@ class OnOffModel(ElementModel):
                 'consecutiveOnHours', self.on,
                 self._on_off_parameters.consecutive_on_hours_min, self._on_off_parameters.consecutive_on_hours_max,
                 system_model, system_model.indices)
-        # offHours:
+
         if self._on_off_parameters.use_consecutive_off_hours:
             self.consecutive_off_hours = self._get_duration_in_hours(
                 'consecutiveOffHours', self.off,
                 self._on_off_parameters.consecutive_off_hours_min, self._on_off_parameters.consecutive_off_hours_max,
                 system_model, system_model.indices)
-        # Var SwitchOn
+
         if self._on_off_parameters.use_switch_on:
             self.switch_on = create_variable('switchOn', self, system_model.nr_of_time_steps, is_binary=True)
             self.switch_off = create_variable('switchOff', self, system_model.nr_of_time_steps, is_binary=True)

--- a/flixOpt/interface.py
+++ b/flixOpt/interface.py
@@ -108,9 +108,19 @@ class OnOffParameters:
                  consecutive_off_hours_min: Optional[Numeric] = None,
                  consecutive_off_hours_max: Optional[Numeric] = None,
                  switch_on_total_max: Optional[int] = None,
-                 force_on: bool = False,
                  force_switch_on: bool = False):
         """
+        on_off_parameters class for modeling on and off state of an Element.
+        If no parameters are given, the default is to create a binary variable for the on state
+        without further constraints or effects and a variable for the total on hours.
+
+        Parameters
+        ----------
+        effects_per_switch_on : scalar, array, TimeSeriesData, optional
+            cost of one switch from off (var_on=0) to on (var_on=1),
+            unit i.g. in Euro
+        effects_per_running_hour : scalar or TS, optional
+            costs for operating, i.g. in € per hour
         on_hours_total_min : scalar, optional
             min. overall sum of operating hours.
         on_hours_total_max : scalar, optional
@@ -125,13 +135,10 @@ class OnOffParameters:
             (last off-time period of timeseries is not checked and can be shorter)
         consecutive_off_hours_max : scalar, optional
             max sum of non-operating hours in one piece
-        effects_per_switch_on : scalar, array, TimeSeriesData, optional
-            cost of one switch from off (var_on=0) to on (var_on=1),
-            unit i.g. in Euro
         switch_on_total_max : integer, optional
             max nr of switchOn operations
-        effects_per_running_hour : scalar or TS, optional
-            costs for operating, i.g. in € per hour
+        force_switch_on : bool
+            force creation of switch on variable, even if there is no switch_on_total_max
         """
         # self.flows_defining_on = flows_defining_on
         # self.on_values_before_begin = on_values_before_begin
@@ -144,7 +151,6 @@ class OnOffParameters:
         self.consecutive_off_hours_min: Numeric_TS = consecutive_off_hours_min  # TimeSeries
         self.consecutive_off_hours_max: Numeric_TS = consecutive_off_hours_max  # TimeSeries
         self.switch_on_total_max = switch_on_total_max
-        self.force_on = force_on  # Can be set to True if needed, even after creation
         self.force_switch_on = force_switch_on
 
     def transform_data(self, owner: 'Element'):
@@ -162,14 +168,6 @@ class OnOffParameters:
 
     def __str__(self):
         return get_object_infos_as_str(self)
-
-    @property
-    def use_on(self) -> bool:
-        """Determines wether the ON Variable is needed or not"""
-        return (any(param is not None for param in [self.effects_per_running_hour,
-                                                    self.on_hours_total_min,
-                                                    self.on_hours_total_max])
-                or self.force_on or self.use_switch_on or self.use_consecutive_on_hours or self.use_consecutive_off_hours or self.use_off)
 
     @property
     def use_off(self) -> bool:


### PR DESCRIPTION
If OnOffParameters are present, the On-Variable is always modeled.
This simplifies the internal logic.