### PR TITLE
Devs/rich logging

### DIFF
--- a/examples/Ex00_minmal/minimal_example.py
+++ b/examples/Ex00_minmal/minimal_example.py
@@ -4,7 +4,7 @@ This script shows how to use the flixOpt framework to model a super minimalistic
 import flixOpt as fx
 
 import numpy as np
-from rich import print  # Used for pretty printing
+from rich.pretty import pprint
 
 if __name__ == '__main__':
 
@@ -55,5 +55,6 @@ if __name__ == '__main__':
     results.plot_operation('District Heating', 'area')
 
     # Print results to the console. Check Results in file or perform more plotting
-    print(calculation.results())
-    print(f'Look into .yaml and .json file for results')
+    pprint(calculation.results())
+    pprint(f'Look into .yaml and .json file for results')
+    pprint(calculation.system_model.main_results)

--- a/examples/Ex00_minmal/minimal_example.py
+++ b/examples/Ex00_minmal/minimal_example.py
@@ -1,9 +1,10 @@
 """
 This script shows how to use the flixOpt framework to model a super minimalistic energy system.
 """
+import flixOpt as fx
 
 import numpy as np
-import flixOpt as fx
+from rich import print  # Used for pretty printing
 
 if __name__ == '__main__':
 

--- a/examples/Ex01_simple/simple_example.py
+++ b/examples/Ex01_simple/simple_example.py
@@ -1,8 +1,8 @@
 """
 THis script shows how to use the flixOpt framework to model a simple energy system.
 """
-
 import numpy as np
+from rich import print  # Used for pretty printing
 import flixOpt as fx
 
 if __name__ == '__main__':

--- a/examples/Ex01_simple/simple_example.py
+++ b/examples/Ex01_simple/simple_example.py
@@ -2,7 +2,7 @@
 THis script shows how to use the flixOpt framework to model a simple energy system.
 """
 import numpy as np
-from rich import print  # Used for pretty printing
+from rich.pretty import pprint  # Used for pretty printing
 import flixOpt as fx
 
 if __name__ == '__main__':
@@ -96,4 +96,4 @@ if __name__ == '__main__':
 
     # Convert the results for the storage component to a dataframe and display
     results.to_dataframe('Storage')
-    print(results.all_results)
+    pprint(results.all_results)

--- a/examples/Ex02_complex/complex_example.py
+++ b/examples/Ex02_complex/complex_example.py
@@ -3,7 +3,7 @@ This script shows how to use the flixOpt framework to model a more complex energ
 """
 import numpy as np
 import pandas as pd
-from rich import print  # Used for pretty printing
+from rich.pretty import pprint  # Used for pretty printing
 import flixOpt as fx
 
 if __name__ == '__main__':
@@ -125,15 +125,15 @@ if __name__ == '__main__':
     flow_system.add_elements(Costs, CO2, PE, Gaskessel, Waermelast, Gasbezug, Stromverkauf, aSpeicher)
     flow_system.add_elements(aKWK2) if use_chp_with_segments else flow_system.add_components(aKWK)
 
-    print(flow_system)  # Get a string representation of the FlowSystem
+    pprint(flow_system)  # Get a string representation of the FlowSystem
 
     # --- Solve FlowSystem ---
     calculation = fx.FullCalculation('Sim1', flow_system, 'pyomo', time_indices)
     calculation.do_modeling()
 
     # Show variables as str (else, you can find them in the results.yaml file
-    print(calculation.system_model.description_of_constraints())
-    print(calculation.system_model.description_of_variables())
+    pprint(calculation.system_model.description_of_constraints())
+    pprint(calculation.system_model.description_of_variables())
 
     calculation.solve(fx.solvers.HighsSolver(mip_gap=0.005, time_limit_seconds=30),  # Specify which solver you want to use and specify parameters
                       save_results='results')  # If and where to save results

--- a/examples/Ex02_complex/complex_example.py
+++ b/examples/Ex02_complex/complex_example.py
@@ -1,9 +1,9 @@
 """
 This script shows how to use the flixOpt framework to model a more complex energy system.
 """
-
 import numpy as np
 import pandas as pd
+from rich import print  # Used for pretty printing
 import flixOpt as fx
 
 if __name__ == '__main__':

--- a/examples/Ex03_calculation_types/example_calculation_types.py
+++ b/examples/Ex03_calculation_types/example_calculation_types.py
@@ -8,6 +8,7 @@ from typing import List, Union, Dict
 
 import numpy as np
 import pandas as pd
+from rich.pretty import pprint  # Used for pretty printing
 
 import flixOpt as fx
 
@@ -148,7 +149,7 @@ if __name__ == '__main__':
         calculation.solve(fx.solvers.HighsSolver())
         calculations['Aggregated'] = calculation
         results['Aggregated'] = calculations['Aggregated'].results()
-
+    pprint(results)
 
     def extract_result(results_data: dict[str, dict], keys: List[str]) -> Dict[str,Union[int, float, np.ndarray]]:
         """

--- a/flixOpt/__init__.py
+++ b/flixOpt/__init__.py
@@ -3,4 +3,4 @@ This module bundles all common functionality of flixOpt and sets up the logging
 """
 
 from .commons import *
-setup_logging('INFO')
+setup_logging('INFO', use_rich_handler=False)

--- a/flixOpt/core.py
+++ b/flixOpt/core.py
@@ -311,11 +311,11 @@ class MultilineFormater(logging.Formatter):
 class ColoredMultilineFormater(MultilineFormater):
     # ANSI escape codes for colors
     COLORS = {
-        'DEBUG': '\033[96m',    # Cyan
-        'INFO': '\033[92m',     # Green
-        'WARNING': '\033[93m',  # Yellow
-        'ERROR': '\033[91m',    # Red
-        'CRITICAL': '\033[91m\033[1m',  # Bold Red
+        'DEBUG': '\033[32m',  # Green
+        'INFO': '\033[34m',  # Blue
+        'WARNING': '\033[33m',  # Yellow
+        'ERROR': '\033[31m',  # Red
+        'CRITICAL': '\033[1m\033[31m',  # Bold Red
     }
     RESET = '\033[0m'
 

--- a/flixOpt/core.py
+++ b/flixOpt/core.py
@@ -288,27 +288,75 @@ def as_effect_dict_with_ts(name_of_param: str,
     return effect_ts_dict
 
 
-def setup_logging(level_name: Literal['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']):
+
+class MultilineFormatter(logging.Formatter):
+    """
+    Custom Formatter that adds timestamps and indents subsequent lines of multiline log messages.
+    """
+
+    def format(self, record):
+        # Format the initial message (first line)
+        base_message = super().format(record)
+
+        # Split the message into lines
+        lines = base_message.splitlines()
+
+        # If the message is empty, return an appropriate placeholder
+        if not lines:
+            return super().format(record)  # Or return a custom placeholder if needed
+
+
+        # Prepare the log prefix (timestamp + log level)
+        timestamp = self.formatTime(record, self.datefmt)
+        log_level = record.levelname.ljust(8)  # Align log levels for consistency
+        log_prefix = f"{timestamp} | {log_level} |"
+
+        # Format all lines
+        first_line = [f'{log_prefix} {lines[0]}']
+        if len(lines) > 1:
+            lines = first_line + [f"{log_prefix} {line}" for line in lines[1:]]
+        else:
+            lines = first_line
+
+        return "\n".join(lines)
+
+def _get_logging_handler(log_file: Optional[str] = None) -> logging.Handler:
+    """Returns a logging handler for the given log file."""
+    if log_file is None:
+        # RichHandler for console output
+        console = Console(width=120)
+        rich_handler = RichHandler(
+            console=console,
+            rich_tracebacks=True,
+            omit_repeated_times=True,
+            show_path=False,
+            log_time_format="%Y-%m-%d %H:%M:%S",
+        )
+        rich_handler.setFormatter(logging.Formatter("%(message)s"))  # Simplified formatting
+
+        return rich_handler
+    else:
+        # FileHandler for file output
+        file_handler = logging.FileHandler(log_file)
+        file_handler.setFormatter(MultilineFormatter(
+            fmt="%(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        ))
+        return file_handler
+
+
+def setup_logging(default_level: Literal['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'] = 'INFO',
+                  log_file: Optional[str] = 'flixOpt.log'):
     """Setup logging configuration"""
     logger = logging.getLogger('flixOpt')  # Use a specific logger name for your package
-    logging_level = get_logging_level_by_name(level_name)
-    logger.setLevel(logging_level)
-
+    logger.setLevel(get_logging_level_by_name(default_level))
     # Clear existing handlers
     if logger.hasHandlers():
         logger.handlers.clear()
 
-    # Configure the RichHandler with the custom console
-    c_handler = RichHandler(console=Console(width=120),
-                            rich_tracebacks=True,
-                            omit_repeated_times=True,
-                            show_path=False,
-                            log_time_format="%Y-%m-%d %H:%M:%S")
-    c_handler.setLevel(logging_level)
-
-    c_handler.setFormatter(logging.Formatter("%(message)s"))
-
-    logger.addHandler(c_handler)
+    logger.addHandler(_get_logging_handler())
+    if log_file is not None:
+        logger.addHandler(_get_logging_handler(log_file))
 
     return logger
 

--- a/flixOpt/core.py
+++ b/flixOpt/core.py
@@ -366,7 +366,7 @@ def _get_logging_handler(log_file: Optional[str] = None,
 
 def setup_logging(default_level: Literal['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'] = 'INFO',
                   log_file: Optional[str] = 'flixOpt.log',
-                  use_rich_handler: bool = True):
+                  use_rich_handler: bool = False):
     """Setup logging configuration"""
     logger = logging.getLogger('flixOpt')  # Use a specific logger name for your package
     logger.setLevel(get_logging_level_by_name(default_level))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "numpy >= 1.21.5, < 2",
     "PyYAML >= 6.0",
     "Pyomo >= 6.4.2",
+    "rich >= 13.0.1",
     "tsam >= 2.3.1",  # Used for time series aggregation
     "highspy >= 1.5.3",  # Default solver
     "pandas >= 2, < 3",  # Used in post-processing


### PR DESCRIPTION
# Rich - a Python library for rich text and beautiful formatting in the terminal.
Adding the package [rich](https://pypi.org/project/rich/) for pretty printing and nicely formatted terminal output.
The beautiful formatting of **rich** only unleashes its full potential in the terminal unfortunately, as colors are only applied there.
It's printing still significantly improves readability, especially of nested dictionaries.
As it's a drop in replacement for the build in `print()` and `pprint()`, it will be used as the default from now ion.

As colored logging with rich does only work when running in the terminal, the current formatting will stay the default, although some color changes were made to match **rich**.
You can enable **rich logging** using the setup logging function at the beginning of your script.
```python
fx.setup_logging(use_rich_handler=True)
```

_PyCharm users will need to enable “emulate terminal” in output console option in run/debug configuration to see styled output._, see the [rich documentation](https://pypi.org/project/rich/).

**Here is a quick guide how to setup the run configuration in PyCharm to fully unlock the potential of rich**
[Run Configurations in PyCharm.pdf](https://github.com/user-attachments/files/18149168/Run.Configurations.in.PyCharm.pdf)

This will enable you to see the output in such a form:
![rich output terminal](https://github.com/user-attachments/assets/36388255-294d-46f0-bf53-923ad2a4e16b)

When run in the **Python Console**, the output is still nicely formatted, but not colored:
![rich output console](https://github.com/user-attachments/assets/525f2360-d239-420b-9781-76c31a4d0f61)
