### PR TITLE
Feature/config

### DIFF
--- a/flixOpt/__init__.py
+++ b/flixOpt/__init__.py
@@ -3,4 +3,6 @@ This module bundles all common functionality of flixOpt and sets up the logging
 """
 
 from .commons import *
-setup_logging('INFO', use_rich_handler=False)
+setup_logging(default_level=CONFIG['logging']['level'],
+              log_file=CONFIG['logging']['file'],
+              use_rich_handler=CONFIG['logging']['rich'])

--- a/flixOpt/__init__.py
+++ b/flixOpt/__init__.py
@@ -3,6 +3,4 @@ This module bundles all common functionality of flixOpt and sets up the logging
 """
 
 from .commons import *
-setup_logging(default_level=CONFIG.logging.level,
-              log_file=CONFIG.logging.file,
-              use_rich_handler=CONFIG.logging.rich)
+CONFIG.load_config()

--- a/flixOpt/__init__.py
+++ b/flixOpt/__init__.py
@@ -3,6 +3,6 @@ This module bundles all common functionality of flixOpt and sets up the logging
 """
 
 from .commons import *
-setup_logging(default_level=CONFIG['logging']['level'],
-              log_file=CONFIG['logging']['file'],
-              use_rich_handler=CONFIG['logging']['rich'])
+setup_logging(default_level=CONFIG.logging.level,
+              log_file=CONFIG.logging.file,
+              use_rich_handler=CONFIG.logging.rich)

--- a/flixOpt/commons.py
+++ b/flixOpt/commons.py
@@ -3,7 +3,7 @@ This module makes the commonly used classes and functions available in the flixO
 """
 
 from .core import TimeSeriesData
-from .config import CONFIG, change_logging_level, setup_logging
+from .config import CONFIG, load_config, change_logging_level, setup_logging
 
 from .elements import Flow, Bus
 from .effects import Effect

--- a/flixOpt/commons.py
+++ b/flixOpt/commons.py
@@ -3,7 +3,7 @@ This module makes the commonly used classes and functions available in the flixO
 """
 
 from .core import TimeSeriesData
-from .config import CONFIG, load_config, change_logging_level, setup_logging
+from .config import CONFIG, change_logging_level
 
 from .elements import Flow, Bus
 from .effects import Effect

--- a/flixOpt/commons.py
+++ b/flixOpt/commons.py
@@ -2,8 +2,8 @@
 This module makes the commonly used classes and functions available in the flixOpt framework.
 """
 
-from .core import setup_logging, change_logging_level, TimeSeriesData
-from .config import CONFIG
+from .core import TimeSeriesData
+from .config import CONFIG, change_logging_level, setup_logging
 
 from .elements import Flow, Bus
 from .effects import Effect

--- a/flixOpt/commons.py
+++ b/flixOpt/commons.py
@@ -3,6 +3,7 @@ This module makes the commonly used classes and functions available in the flixO
 """
 
 from .core import setup_logging, change_logging_level, TimeSeriesData
+from .config import CONFIG
 
 from .elements import Flow, Bus
 from .effects import Effect

--- a/flixOpt/components.py
+++ b/flixOpt/components.py
@@ -9,7 +9,7 @@ from typing import Union, Optional, Literal, List, Dict, Tuple, Set
 
 from . import utils
 from .elements import Flow, _create_time_series
-from .core import Skalar, Numeric_TS, TimeSeries, Numeric
+from .core import Skalar, Numeric, Numeric_TS, TimeSeries
 from .math_modeling import VariableTS, Equation
 from .features import OnOffModel, MultipleSegmentsModel, InvestmentModel
 from .structure import SystemModel, create_equation, create_variable

--- a/flixOpt/config.py
+++ b/flixOpt/config.py
@@ -117,6 +117,10 @@ class CONFIG:
         cls.modeling = config_data.modeling
         cls.config_name = config_data.config_name
 
+        setup_logging(default_level=cls.logging.level,
+                      log_file=cls.logging.file,
+                      use_rich_handler=cls.logging.rich)
+
     @classmethod
     def to_dict(cls):
         """

--- a/flixOpt/config.py
+++ b/flixOpt/config.py
@@ -1,0 +1,78 @@
+import os
+from typing import Optional, Union, TypedDict, Literal
+import logging
+
+import yaml
+
+logger = logging.getLogger('flixOpt')
+
+
+def merge_configs(defaults: dict, overrides: dict) -> dict:
+    """
+    Merge the default configuration with user-provided overrides.
+
+    :param defaults: Default configuration dictionary.
+    :param overrides: User configuration dictionary.
+    :return: Merged configuration dictionary.
+    """
+    for key, value in overrides.items():
+        if isinstance(value, dict) and key in defaults and isinstance(defaults[key], dict):
+            # Recursively merge nested dictionaries
+            defaults[key] = merge_configs(defaults[key], value)
+        else:
+            # Override the default value
+            defaults[key] = value
+    return defaults
+
+
+class LoggingConfig(TypedDict):
+    level: Literal['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
+    file: str
+    rich: bool
+
+
+class ModelingConfig(TypedDict):
+    BIG: int
+    EPSILON: float
+    BIG_BINARY_BOUND: int
+
+
+class ConfigSchema(TypedDict):
+    logging: LoggingConfig
+    modeling: ModelingConfig
+
+
+def load_config(config_file: Optional[str] = None) -> ConfigSchema:
+    """
+    Load the configuration, merging user-provided config with defaults.
+
+    :param config_file: Path to the user's config file (optional).
+    :return: Configuration dictionary.
+    """
+    # Path to the default package config
+    default_config_path = os.path.join(os.path.dirname(__file__), "config.yaml")
+
+    # Load the default config
+    with open(default_config_path, "r") as file:
+        config = yaml.safe_load(file)
+
+    if config_file is None:
+        return ConfigSchema(**config)
+
+    # If the user provides a custom config, merge it with the defaults
+    elif not os.path.exists(config_file):
+        logger.error(f"No user config file found at {config_file}. Default config will be used.")
+    else:
+        with open(config_file, "r") as user_file:
+            user_config = yaml.safe_load(user_file)
+            config = merge_configs(config, user_config)
+            logger.info(f"Loaded user config from {config_file}")
+        try:
+            return ConfigSchema(**config)
+        except TypeError as e:
+            logger.critical(f'Invalid config file: {e}. \nPlease check your config file "{config_file}" and try again.')
+            raise e
+
+
+# Load the configuration and make it globally accessible
+CONFIG: ConfigSchema = load_config()

--- a/flixOpt/config.py
+++ b/flixOpt/config.py
@@ -86,11 +86,9 @@ class CONFIG:
     """
     A configuration class that stores global configuration values as class attributes.
     """
-
-    # Default configuration attributes
-    logging: LoggingConfig = None
-    modeling: ModelingConfig = None
     config_name: str = None
+    modeling: ModelingConfig = None
+    logging: LoggingConfig = None
 
     @classmethod
     def load_config(cls, user_config_file: Optional[str] = None):

--- a/flixOpt/config.yaml
+++ b/flixOpt/config.yaml
@@ -1,0 +1,10 @@
+# Default configuration of flixOpt
+config_name: flixOpt  # Name of the config file. This has no effect on the configuration itself.
+logging:
+  level: INFO
+  file: flixOpt.log
+  rich: false  # logging output is formatted using rich. This is only advisable when using a proper terminal
+modeling:
+  BIG: 10000000  # 1e notation not possible in yaml
+  EPSILON: 0.00001
+  BIG_BINARY_BOUND: 100000

--- a/flixOpt/core.py
+++ b/flixOpt/core.py
@@ -25,50 +25,6 @@ Numeric_TS = Union[Skalar, np.ndarray, 'TimeSeries']
 #   TimeSeriesData      --> wie obige aber zusätzliche Übergabe aggWeight (für Aggregation)
 
 
-class Config:
-    """
-    Configuration class for global settings.
-    The values are used as defaults in several classes.
-    They can be overwritten by the user via the .update() - method.
-    Use with care, and make sure to adjust them in the beginning of the script.
-    """
-    BIG_M: Union[int, float] = 1e7
-    EPSILON: Union[int, float] = 1e-5
-    OFFSET_TO_BIG_M: Union[int, float] = 100
-    BIG_BINARY_BOUND: Union[int, float] = BIG_M / OFFSET_TO_BIG_M
-
-    @classmethod
-    def update(cls, big_m: Optional[int] = None,
-               epsilon: Optional[float] = None,
-               offset_to_big_m: Optional[int] = None,
-               big_binary_bound: Optional[int] = None) -> None:
-        """
-        Update the configuration with the given values.
-        -----
-        Parameters
-        -----------
-        big_m: int, optional
-            The value of the big M constant. Defaults to 1e7.
-        epsilon: float, optional
-            The value of the epsilon constant. Defaults to 1e-5.
-        offset_to_big_m: int, optional
-            The value of the offset to big M constant for the big binary bound. Defaults to 100.
-        big_binary_bound: int, optional
-            The value of the big binary bound. Defaults to the value of big M minus the offset to big M.
-            Use either this or the offset!
-        """
-        if big_binary_bound is not None and offset_to_big_m is not None:
-            raise ValueError(f'Either use "offset_to_big_m" or set the "big_binary_bound" directly. Not Both')
-        if big_m is not None:
-            cls.BIG_M = big_m
-        if epsilon is not None:
-            cls.EPSILON = epsilon
-        if big_binary_bound is not None:
-            cls.BIG_BINARY_BOUND = big_binary_bound
-        if offset_to_big_m is not None:
-            cls.BIG_BINARY_BOUND = cls.BIG_M / offset_to_big_m
-
-
 class TimeSeriesData:
     # TODO: Move to Interface.py
     def __init__(self,

--- a/flixOpt/elements.py
+++ b/flixOpt/elements.py
@@ -8,7 +8,8 @@ import logging
 import numpy as np
 
 from .math_modeling import Variable, VariableTS
-from .core import Numeric, Numeric_TS, Skalar, Config
+from .core import Numeric, Numeric_TS, Skalar
+from .config import CONFIG
 from .interface import InvestParameters, OnOffParameters
 from .features import OnOffModel, InvestmentModel, PreventSimultaneousUsageModel
 from .structure import SystemModel, Element, ElementModel, _create_time_series, create_equation, create_variable, \
@@ -202,7 +203,7 @@ class Flow(Element):
             previous flow rate of the component.
         """
         super().__init__(label, meta_data=meta_data)
-        self.size = size or Config.BIG_M  # Default size
+        self.size = size or CONFIG['modeling']['BIG']  # Default size
         self.relative_minimum = relative_minimum
         self.relative_maximum = relative_maximum
         self.fixed_relative_profile = fixed_relative_profile
@@ -246,7 +247,7 @@ class Flow(Element):
         if np.any(self.relative_minimum > self.relative_maximum):
             raise Exception(self.label_full + ': Take care, that relative_minimum <= relative_maximum!')
 
-        if self.size == Config.BIG_M and self.fixed_relative_profile is not None:  # Default Size --> Most likely by accident
+        if self.size == CONFIG['modeling']['BIG'] and self.fixed_relative_profile is not None:  # Default Size --> Most likely by accident
             raise Exception('Achtung: Wenn fixed_relative_profile genutzt wird, muss zugehöriges size definiert werden, '
                             'da: value = fixed_relative_profile * size!')
 

--- a/flixOpt/elements.py
+++ b/flixOpt/elements.py
@@ -203,7 +203,7 @@ class Flow(Element):
             previous flow rate of the component.
         """
         super().__init__(label, meta_data=meta_data)
-        self.size = size or CONFIG['modeling']['BIG']  # Default size
+        self.size = size or CONFIG.modeling.BIG  # Default size
         self.relative_minimum = relative_minimum
         self.relative_maximum = relative_maximum
         self.fixed_relative_profile = fixed_relative_profile
@@ -247,7 +247,7 @@ class Flow(Element):
         if np.any(self.relative_minimum > self.relative_maximum):
             raise Exception(self.label_full + ': Take care, that relative_minimum <= relative_maximum!')
 
-        if self.size == CONFIG['modeling']['BIG'] and self.fixed_relative_profile is not None:  # Default Size --> Most likely by accident
+        if self.size == CONFIG.modeling.BIG and self.fixed_relative_profile is not None:  # Default Size --> Most likely by accident
             raise Exception('Achtung: Wenn fixed_relative_profile genutzt wird, muss zugehöriges size definiert werden, '
                             'da: value = fixed_relative_profile * size!')
 

--- a/flixOpt/features.py
+++ b/flixOpt/features.py
@@ -120,7 +120,7 @@ class InvestmentModel(ElementModel):
             # eq2: P_invest >= isInvested * max(epsilon, investSize_min)
             eq_is_invested_lb = create_equation('is_invested_lb', self, 'ineq')
             eq_is_invested_lb.add_summand(self.size, -1)
-            eq_is_invested_lb.add_summand(self.is_invested, np.maximum(CONFIG['modeling']['EPSILON'], self._invest_parameters.minimum_size))
+            eq_is_invested_lb.add_summand(self.is_invested, np.maximum(CONFIG.modeling.EPSILON, self._invest_parameters.minimum_size))
 
     def _create_bounds_for_defining_variable(self, system_model: SystemModel):
         label = self._defining_variable.label
@@ -192,7 +192,7 @@ class OnOffModel(ElementModel):
 
     def do_modeling(self, system_model: SystemModel):
         self.on = create_variable('on', self, system_model.nr_of_time_steps, is_binary=True,
-                                  previous_values=self._previous_on_values(CONFIG['modeling']['EPSILON']))
+                                  previous_values=self._previous_on_values(CONFIG.modeling.EPSILON))
 
         self.total_on_hours = create_variable('totalOnHours', self, 1,
                                               lower_bound=self._on_off_parameters.on_hours_total_min,
@@ -205,7 +205,7 @@ class OnOffModel(ElementModel):
 
         if self._on_off_parameters.use_off:
             self.off = create_variable('off', self, system_model.nr_of_time_steps, is_binary=True,
-                                       previous_values=1 - self._previous_on_values(CONFIG['modeling']['EPSILON']))
+                                       previous_values=1 - self._previous_on_values(CONFIG.modeling.EPSILON))
 
             self._add_off_constraints(system_model, system_model.indices)
 
@@ -249,7 +249,7 @@ class OnOffModel(ElementModel):
             #### Bedingung 1) ####
             # eq: On(t) * max(epsilon, lower_bound) <= Q_th(t)
             eq_on_1.add_summand(variable, -1, time_indices)
-            eq_on_1.add_summand(self.on, np.maximum(CONFIG['modeling']['EPSILON'], lower_bound), time_indices)
+            eq_on_1.add_summand(self.on, np.maximum(CONFIG.modeling.EPSILON, lower_bound), time_indices)
 
             #### Bedingung 2) ####
             # eq: Q_th(t) <= Q_th_max * On(t)
@@ -262,7 +262,7 @@ class OnOffModel(ElementModel):
             # eq: - sum(alle Leistungen(t)) + Epsilon * On(t) <= 0
             for variable in self._defining_variables:
                 eq_on_1.add_summand(variable, -1, time_indices)
-            eq_on_1.add_summand(self.on, CONFIG['modeling']['EPSILON'], time_indices)
+            eq_on_1.add_summand(self.on, CONFIG.modeling.EPSILON, time_indices)
 
             #### Bedingung 2) ####
             ## sum(alle Leistung) >0 -> On = 1 | On=0 -> sum(Leistung)=0
@@ -277,7 +277,7 @@ class OnOffModel(ElementModel):
             upper_bound = absolute_maximum / nr_of_defining_variables
             eq_on_2.add_summand(self.on, -1 * upper_bound, time_indices)
 
-        if np.max(upper_bound) > CONFIG['modeling']['BIG_BINARY_BOUND']:
+        if np.max(upper_bound) > CONFIG.modeling.BIG_BINARY_BOUND:
             logger.warning(
                 f'In "{self.element.label_full}", a binary definition was created with a big upper bound '
                 f'({np.max(upper_bound)}). This can lead to wrong results regarding the on and off variables. '

--- a/flixOpt/features.py
+++ b/flixOpt/features.py
@@ -9,7 +9,8 @@ import logging
 import numpy as np
 
 from .math_modeling import Variable, VariableTS, Equation
-from .core import TimeSeries, Skalar, Numeric, Config
+from .core import TimeSeries, Skalar, Numeric
+from .config import CONFIG
 from .interface import InvestParameters, OnOffParameters
 from .structure import ElementModel, SystemModel, Element, create_equation, create_variable
 
@@ -119,7 +120,7 @@ class InvestmentModel(ElementModel):
             # eq2: P_invest >= isInvested * max(epsilon, investSize_min)
             eq_is_invested_lb = create_equation('is_invested_lb', self, 'ineq')
             eq_is_invested_lb.add_summand(self.size, -1)
-            eq_is_invested_lb.add_summand(self.is_invested, np.maximum(Config.EPSILON, self._invest_parameters.minimum_size))
+            eq_is_invested_lb.add_summand(self.is_invested, np.maximum(CONFIG['modeling']['EPSILON'], self._invest_parameters.minimum_size))
 
     def _create_bounds_for_defining_variable(self, system_model: SystemModel):
         label = self._defining_variable.label
@@ -191,7 +192,7 @@ class OnOffModel(ElementModel):
 
     def do_modeling(self, system_model: SystemModel):
         self.on = create_variable('on', self, system_model.nr_of_time_steps, is_binary=True,
-                                  previous_values=self._previous_on_values(Config.EPSILON))
+                                  previous_values=self._previous_on_values(CONFIG['modeling']['EPSILON']))
 
         self.total_on_hours = create_variable('totalOnHours', self, 1,
                                               lower_bound=self._on_off_parameters.on_hours_total_min,
@@ -204,7 +205,7 @@ class OnOffModel(ElementModel):
 
         if self._on_off_parameters.use_off:
             self.off = create_variable('off', self, system_model.nr_of_time_steps, is_binary=True,
-                                       previous_values=1 - self._previous_on_values(Config.EPSILON))
+                                       previous_values=1 - self._previous_on_values(CONFIG['modeling']['EPSILON']))
 
             self._add_off_constraints(system_model, system_model.indices)
 
@@ -248,7 +249,7 @@ class OnOffModel(ElementModel):
             #### Bedingung 1) ####
             # eq: On(t) * max(epsilon, lower_bound) <= Q_th(t)
             eq_on_1.add_summand(variable, -1, time_indices)
-            eq_on_1.add_summand(self.on, np.maximum(Config.EPSILON, lower_bound), time_indices)
+            eq_on_1.add_summand(self.on, np.maximum(CONFIG['modeling']['EPSILON'], lower_bound), time_indices)
 
             #### Bedingung 2) ####
             # eq: Q_th(t) <= Q_th_max * On(t)
@@ -261,7 +262,7 @@ class OnOffModel(ElementModel):
             # eq: - sum(alle Leistungen(t)) + Epsilon * On(t) <= 0
             for variable in self._defining_variables:
                 eq_on_1.add_summand(variable, -1, time_indices)
-            eq_on_1.add_summand(self.on, Config.EPSILON, time_indices)
+            eq_on_1.add_summand(self.on, CONFIG['modeling']['EPSILON'], time_indices)
 
             #### Bedingung 2) ####
             ## sum(alle Leistung) >0 -> On = 1 | On=0 -> sum(Leistung)=0
@@ -276,7 +277,7 @@ class OnOffModel(ElementModel):
             upper_bound = absolute_maximum / nr_of_defining_variables
             eq_on_2.add_summand(self.on, -1 * upper_bound, time_indices)
 
-        if np.max(upper_bound) > Config.BIG_BINARY_BOUND:
+        if np.max(upper_bound) > CONFIG['modeling']['BIG_BINARY_BOUND']:
             logger.warning(
                 f'In "{self.element.label_full}", a binary definition was created with a big upper bound '
                 f'({np.max(upper_bound)}). This can lead to wrong results regarding the on and off variables. '

--- a/flixOpt/interface.py
+++ b/flixOpt/interface.py
@@ -6,7 +6,8 @@ These are tightly connected to features.py
 import logging
 from typing import Union, Optional, Dict, List, Tuple, TYPE_CHECKING
 
-from .core import Numeric, Skalar, Numeric_TS, Config
+from .core import Numeric, Skalar, Numeric_TS
+from .config import CONFIG
 from .structure import get_object_infos_as_str, get_object_infos_as_dict
 if TYPE_CHECKING:
     from .structure import Element
@@ -71,7 +72,7 @@ class InvestParameters:
         self.specific_effects: EffectValuesInvest = specific_effects
         self.effects_in_segments = effects_in_segments
         self._minimum_size = minimum_size
-        self._maximum_size = maximum_size or Config.BIG_M  # default maximum
+        self._maximum_size = maximum_size or CONFIG['modeling']['BIG']  # default maximum
     
     def transform_data(self):
         from .effects import as_effect_dict

--- a/flixOpt/interface.py
+++ b/flixOpt/interface.py
@@ -72,7 +72,7 @@ class InvestParameters:
         self.specific_effects: EffectValuesInvest = specific_effects
         self.effects_in_segments = effects_in_segments
         self._minimum_size = minimum_size
-        self._maximum_size = maximum_size or CONFIG['modeling']['BIG']  # default maximum
+        self._maximum_size = maximum_size or CONFIG.modeling.BIG  # default maximum
     
     def transform_data(self):
         from .effects import as_effect_dict

--- a/flixOpt/structure.py
+++ b/flixOpt/structure.py
@@ -13,6 +13,7 @@ import numpy as np
 from . import utils
 from .math_modeling import MathModel, Variable, Equation, Inequation, VariableTS, Solver
 from .core import TimeSeries, Skalar, Numeric, Numeric_TS, TimeSeriesData
+from .config import CONFIG
 
 if TYPE_CHECKING:  # for type checking and preventing circular imports
     from .flow_system import FlowSystem
@@ -166,6 +167,7 @@ class SystemModel(MathModel):
         infos['Constraints'] = self.description_of_constraints()
         infos['Variables'] = self.description_of_variables()
         infos['Main Results'] = self.main_results
+        infos['Config'] = CONFIG.to_dict()
         return infos
 
     @property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,3 +58,6 @@ repository = "https://github.com/flixOpt/flixOpt"
 [tool.setuptools.packages.find]
 where = ["."]
 exclude = ["tests", "docs", "examples", "examples.*", "Tutorials", ".git", ".vscode", "build", ".venv", "venv/"]
+
+[tool.setuptools.package-data]
+"flixOpt" = ["config.yaml"]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -17,7 +17,7 @@ np.random.seed(45)
 
 class BaseTest(unittest.TestCase):
     def setUp(self):
-        setup_logging("DEBUG")
+        change_logging_level("DEBUG")
 
     def get_solver(self):
         return solvers.HighsSolver(mip_gap=0.0001, time_limit_seconds=3600, solver_output_to_console=False)


### PR DESCRIPTION
# Adding a CONFIG to flixOpt
To control central behaviour of flixOpt without hard coding it, we introduce a CONFIG.
a default config is provided and loaded when importing the package.
The values are validated on import.
CUrrently there are Configs for:
## Logging
- logging_level
- logging_file
- rich: use the rich logging (for terminal formatting)
# modeling
- BIG
- EPSILON
- BIG_BINARY_BOUND

If the user desires to change these values, he has to provide his own config_file.
```python
import flixOpt as fx

import numpy as np

if __name__ == '__main__':
    fx.CONFIG.load_config('new_config.yaml')
    # --- Define Thermal Load Profile ---
    # Load profile (e.g., kW) for heating demand over time
    thermal_load_profile = np.array([30., 0., 20.])
    ...
```
This has to be done at the beginning of your script, to work as expected.
__This is currently the only way to reliably change the config values!__

To change the logging level without a config file, use the existing function:
```python
fx.change_logging_level('DEBUG')


