### PR TITLE
Make minimum duration work with scalars again

### DIFF
--- a/flixOpt/features.py
+++ b/flixOpt/features.py
@@ -386,7 +386,10 @@ class OnOffModel(ElementModel):
             # Note: (previous values before t=1 are not recognised!)
             # eq: duration(t) >= minimum_duration(t) * [On(t) - On(t+1)] for t=1..(n-1)
             # eq: -duration(t) + minimum_duration(t) * On(t) - minimum_duration(t) * On(t+1) <= 0
-            minimum_duration_used = minimum_duration.active_data[0:-1] # only checked for t=1...(n-1)
+            if minimum_duration.is_scalar:
+                minimum_duration_used = minimum_duration.active_data
+            else:
+                minimum_duration_used = minimum_duration.active_data[0:-1]  # only checked for t=1...(n-1)
             eq_min_duration = create_equation(f'{label_prefix}_minimum_duration', self, eq_type='ineq')
             eq_min_duration.add_summand(duration_in_hours, -1, time_indices[0:-1])  # -duration(t)
             eq_min_duration.add_summand(binary_variable, -1 * minimum_duration_used, time_indices[1:])  # - minimum_duration (t) * On(t+1)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -367,7 +367,7 @@ class TestComplex(BaseTest):
         aGaskessel = Boiler('Kessel', eta=0.5, on_off_parameters=OnOffParameters(effects_per_running_hour={costs: 0, CO2: 1000}),
                             Q_th=Flow('Q_th', bus=Fernwaerme, load_factor_max=1.0, load_factor_min=0.1, relative_minimum=5 / 50, relative_maximum=1, previous_flow_rate=50,
                                       size=InvestParameters(fix_effects=1000, fixed_size=50, optional=False, specific_effects={costs: 10, PE: 2}),
-                                      can_be_off=OnOffParameters(on_hours_total_min=0, on_hours_total_max=1000, consecutive_on_hours_max=10, consecutive_off_hours_max=10, effects_per_switch_on=0.01, switch_on_total_max=1000),
+                                      can_be_off=OnOffParameters(on_hours_total_min=0, on_hours_total_max=1000, consecutive_on_hours_max=10, consecutive_on_hours_min =1,consecutive_off_hours_max=10, effects_per_switch_on=0.01, switch_on_total_max=1000),
                                       flow_hours_total_max=1e6),
                             Q_fu=Flow('Q_fu', bus=Gas, size=200, relative_minimum=0, relative_maximum=1))
 


### PR DESCRIPTION
Previous bug fixed introduced a new bug.
If .active_data is not an array, it can't be subscripted.