### PR TITLE
Feature/127 save results in zip file

### DIFF
--- a/flixOpt/calculation.py
+++ b/flixOpt/calculation.py
@@ -79,22 +79,23 @@ class Calculation:
             path.mkdir(parents=True, exist_ok=True)  # Pfad anlegen, fall noch nicht vorhanden:
 
             self._paths["log"] = path / f'{self.name}_solver.log'
-            self._paths["data"] = path / f'{self.name}_data.json'
-            self._paths["results"] = path / f'{self.name}_results.json'
+            self._paths["data"] = path / f'{self.name}_data.zip'
             self._paths["infos"] = path / f'{self.name}_infos.yaml'
 
     def _save_solve_infos(self):
         import yaml
         import json
+        import zipfile
 
         t_start = timeit.default_timer()
-        with open(self._paths['results'], 'w', encoding='utf-8') as f:
-            results = utils.convert_to_native_types(self.results())
-            json.dump(results, f, indent=4)
 
-        with open(self._paths['data'], 'w', encoding='utf-8') as f:
-            data = utils.convert_to_native_types(self.flow_system.infos())
-            json.dump(data, f, indent=4)
+        with zipfile.ZipFile(self._paths["data"], 'w', compression=zipfile.ZIP_DEFLATED) as zipf:
+            with zipf.open('results.json', 'w') as file:
+                results = utils.convert_to_native_types(self.results())
+                file.write(json.dumps(results, indent=4).encode('utf-8'))
+            with zipf.open('data.json', 'w') as file:
+                data = utils.convert_to_native_types(self.flow_system.infos())
+                file.write(json.dumps(data, indent=4).encode('utf-8'))
 
         self.durations['saving'] = round(timeit.default_timer() - t_start, 2)
 
@@ -390,20 +391,24 @@ class SegmentedCalculation(Calculation):
     def _save_solve_infos(self):
         import yaml
         import json
+        import zipfile
 
         t_start = timeit.default_timer()
-        with open(self._paths['results'], 'w', encoding='utf-8') as f:
-            results = utils.convert_to_native_types(self.results(combined_arrays=True))
-            json.dump(results, f, indent=4)
 
-        with open(self._paths['data'], 'w', encoding='utf-8') as f:
-            data = utils.convert_to_native_types(self.flow_system.infos())
-            json.dump(data, f, indent=4)
+        with zipfile.ZipFile(self._paths["data"], 'w', compression=zipfile.ZIP_DEFLATED) as zipf:
+            with zipf.open('results.json', 'w') as file:
+                results = utils.convert_to_native_types(self.results(combined_arrays=True))
+                file.write(json.dumps(results, indent=4).encode('utf-8'))
+            with zipf.open('data.json', 'w') as file:
+                data = utils.convert_to_native_types(self.flow_system.infos())
+                file.write(json.dumps(data, indent=4).encode('utf-8'))
 
-        with open(self._paths['results'].parent / f'{self.name}_results_extra.json', 'w', encoding='utf-8') as f:
-            results = {'Individual Results': utils.convert_to_native_types(self.results(individual_results=True)),
-                       'Skalar Results': utils.convert_to_native_types(self.results(combined_scalars=True))}
-            json.dump(results, f, indent=4)
+            with zipf.open('results_extra.json', 'w') as file:
+                results = {
+                    'Individual Results': utils.convert_to_native_types(self.results(individual_results=True)),
+                    'Skalar Results': utils.convert_to_native_types(self.results(combined_scalars=True))}
+                file.write(json.dumps(results, indent=4).encode('utf-8'))
+
         self.durations['saving'] = round(timeit.default_timer() - t_start, 2)
 
         t_start = timeit.default_timer()

--- a/flixOpt/results.py
+++ b/flixOpt/results.py
@@ -7,6 +7,7 @@ The results can also be analyzed without this module, as the results are stored 
 
 import logging
 import json
+import zipfile
 import pathlib
 from typing import Dict, List, Tuple, Literal, Optional, Union
 import datetime
@@ -42,8 +43,7 @@ class CalculationResults:
         self.name = calculation_name
         self.folder = pathlib.Path(folder)
         self._path_infos = (self.folder / f'{calculation_name}_infos.yaml').resolve().as_posix()
-        self._path_data = (self.folder / f'{calculation_name}_data.json').resolve().as_posix()
-        self._path_results = (self.folder / f'{calculation_name}_results.json').resolve().as_posix()
+        self._path_data = (self.folder / f'{calculation_name}_data.zip').resolve().as_posix()
 
         start_time = timeit.default_timer()
         with open(self._path_infos, 'rb') as f:
@@ -51,14 +51,12 @@ class CalculationResults:
         logger.info(f'Loading Calculation Infos from .yaml took {(timeit.default_timer() - start_time):>8.2f} seconds')
 
         start_time = timeit.default_timer()
-        with open(self._path_results, 'rb') as f:
-            self.all_results: Dict = json.load(f)
+        with zipfile.ZipFile(self._path_data, 'r') as zipf:
+            with zipf.open('results.json', 'r') as f:
+                self.all_results: Dict = json.load(f)
+            with zipf.open('data.json', 'r') as f:
+                self.all_data: Dict = json.load(f)
         self.all_results = utils.convert_numeric_lists_to_arrays(self.all_results)
-        logger.info(f'Loading results from .json took {(timeit.default_timer() - start_time):>8.2f} seconds')
-
-        start_time = timeit.default_timer()
-        with open(self._path_data, 'rb') as f:
-            self.all_data: Dict = json.load(f)
         self.all_data = utils.convert_numeric_lists_to_arrays(self.all_data)
         logger.info(f'Loading data from .json took {(timeit.default_timer() - start_time):>8.2f} seconds')
 


### PR DESCRIPTION
# Saving results in .zip file
To reduce the footprint of CalcualtionResults, Results are now stored in a .zip file.
When trying to load results, if no .zip is found, it will fall back to search for the 2 .json files. This will raise a warning.
Saving without zipping is not supported.
See #127 and #57