### PR TITLE
Next/patch

### DIFF
--- a/examples/02_Complex/complex_example.py
+++ b/examples/02_Complex/complex_example.py
@@ -57,6 +57,7 @@ if __name__ == '__main__':
                          on_hours_total_min=0,  # Minimum operating hours
                          on_hours_total_max=1000,  # Maximum operating hours
                          consecutive_on_hours_max=10,  # Max consecutive operating hours
+                         consecutive_on_hours_min=np.array([1., 1., 1., 1, 1, 2, 2, 2, 2]), # min consecutive operation hours
                          consecutive_off_hours_max=10,  # Max consecutive off hours
                          effects_per_switch_on=0.01,  # Cost per switch-on
                          switch_on_total_max=1000),  # Max number of starts

--- a/flixOpt/aggregation.py
+++ b/flixOpt/aggregation.py
@@ -326,7 +326,7 @@ class AggregationModel(ElementModel):
 
     def do_modeling(self, system_model: SystemModel):
         if not self.components_to_clusterize:
-            components = self.flow_system.components
+            components = self.flow_system.components.values()
         else:
             components = [component for component in self.components_to_clusterize]
 

--- a/flixOpt/calculation.py
+++ b/flixOpt/calculation.py
@@ -19,7 +19,7 @@ import numpy as np
 
 from .aggregation import TimeSeriesCollection, AggregationParameters, AggregationModel
 from .core import Numeric, Skalar
-from .structure import SystemModel
+from .structure import SystemModel, copy_and_convert_datatypes
 from .flow_system import FlowSystem
 from .elements import Component
 from .components import Storage
@@ -89,11 +89,11 @@ class Calculation:
 
         t_start = timeit.default_timer()
         with open(self._paths['results'], 'w', encoding='utf-8') as f:
-            results = utils.convert_to_native_types(self.results())
+            results = copy_and_convert_datatypes(self.results(), use_numpy=False, use_element_label=False)
             json.dump(results, f, indent=4)
 
         with open(self._paths['data'], 'w', encoding='utf-8') as f:
-            data = utils.convert_to_native_types(self.flow_system.infos())
+            data = copy_and_convert_datatypes(self.flow_system.infos(), use_numpy=False, use_element_label=False)
             json.dump(data, f, indent=4)
 
         self.durations['saving'] = round(timeit.default_timer() - t_start, 2)
@@ -320,8 +320,8 @@ class SegmentedCalculation(Calculation):
 
         # Storing all original start values
         self._original_start_values = {
-            **{flow: flow.previous_flow_rate for flow in self.flow_system.all_flows},
-            **{comp: comp.initial_charge_state for comp in self.flow_system.components if isinstance(comp, Storage)}
+            **{flow: flow.previous_flow_rate for flow in self.flow_system.flows.values()},
+            **{comp: comp.initial_charge_state for comp in self.flow_system.components.values() if isinstance(comp, Storage)}
         }
         self._transfered_start_values: Dict[str, Dict[str, Any]] = {}
 
@@ -393,16 +393,23 @@ class SegmentedCalculation(Calculation):
 
         t_start = timeit.default_timer()
         with open(self._paths['results'], 'w', encoding='utf-8') as f:
-            results = utils.convert_to_native_types(self.results(combined_arrays=True))
+            results = copy_and_convert_datatypes(
+                self.results(combined_arrays=True), use_numpy=False, use_element_label=False
+            )
             json.dump(results, f, indent=4)
 
         with open(self._paths['data'], 'w', encoding='utf-8') as f:
-            data = utils.convert_to_native_types(self.flow_system.infos())
+            data = copy_and_convert_datatypes(self.flow_system.infos(), use_numpy=False, use_element_label=False)
             json.dump(data, f, indent=4)
 
         with open(self._paths['results'].parent / f'{self.name}_results_extra.json', 'w', encoding='utf-8') as f:
-            results = {'Individual Results': utils.convert_to_native_types(self.results(individual_results=True)),
-                       'Skalar Results': utils.convert_to_native_types(self.results(combined_scalars=True))}
+            results = {
+                'Individual Results': copy_and_convert_datatypes(
+                    self.results(individual_results=True), use_numpy=False, use_element_label=False
+                ),
+                'Skalar Results': copy_and_convert_datatypes(
+                    self.results(combined_scalars=True), use_numpy=False, use_element_label=False)
+            }
             json.dump(results, f, indent=4)
         self.durations['saving'] = round(timeit.default_timer() - t_start, 2)
 
@@ -433,10 +440,10 @@ class SegmentedCalculation(Calculation):
         """
         final_index_of_prior_segment = - (1 + self.overlap_length)
         start_values_of_this_segment = {}
-        for flow in self.flow_system.all_flows:
+        for flow in self.flow_system.flows.values():
             flow.previous_flow_rate = flow.model.flow_rate.result[final_index_of_prior_segment]  #TODO: maybe more values?
             start_values_of_this_segment[flow.label_full] = flow.previous_flow_rate
-        for comp in self.flow_system.components:
+        for comp in self.flow_system.components.values():
             if isinstance(comp, Storage):
                 comp.initial_charge_state = comp.model.charge_state.result[final_index_of_prior_segment]
                 start_values_of_this_segment[comp.label_full] = comp.initial_charge_state
@@ -445,9 +452,9 @@ class SegmentedCalculation(Calculation):
 
     def _reset_start_values(self):
         """ This resets the start values of all Elements to its original state"""
-        for flow in self.flow_system.all_flows:
+        for flow in self.flow_system.flows.values():
             flow.previous_flow_rate = self._original_start_values[flow]
-        for comp in self.flow_system.components:
+        for comp in self.flow_system.components.values():
             if isinstance(comp, Storage):
                 comp.initial_charge_state = self._original_start_values[comp]
 

--- a/flixOpt/elements.py
+++ b/flixOpt/elements.py
@@ -249,7 +249,7 @@ class Flow(Element):
             
         if self.size == CONFIG.modeling.BIG and self.fixed_relative_profile is not None:  # Default Size --> Most likely by accident
             logger.warning(f'Flow "{self.label}" has no size assigned, but a "fixed_relative_profile". '
-                           f'The default size is {Config.BIG_M}. As "flow_rate = size * fixed_relative_profile", '
+                           f'The default size is {CONFIG.modeling.BIG}. As "flow_rate = size * fixed_relative_profile", '
                            f'the resulting flow_rate will be very high. To fix this, assign a size to the Flow {self}.')
 
     @property

--- a/flixOpt/features.py
+++ b/flixOpt/features.py
@@ -357,6 +357,8 @@ class OnOffModel(ElementModel):
         constraint_1.add_summand(binary_variable, -1 * mega)
 
         # 2a) eq: duration(t) - duration(t-1) <= dt(t)
+        #    on(t)=1 -> duration(t) - duration(t-1) <= dt(t)
+        #    on(t)=0 -> duration(t-1) >= negat. value
         constraint_2a = create_equation(f'{label_prefix}_constraint_2a', self, eq_type='ineq')
         constraint_2a.add_summand(duration_in_hours, 1, time_indices[1:])  # duration(t)
         constraint_2a.add_summand(duration_in_hours, -1, time_indices[0:-1])  # duration(t-1)
@@ -364,6 +366,10 @@ class OnOffModel(ElementModel):
 
         # 2b) eq: dt(t) - BIG * ( 1-On(t) ) <= duration(t) - duration(t-1)
         # eq: -duration(t) + duration(t-1) + On(t) * BIG <= -dt(t) + BIG
+        # with BIG = dt_in_hours_total.
+        #   on(t)=1 -> duration(t)- duration(t-1) >= dt(t)
+        #   on(t)=0 -> duration(t)- duration(t-1) >= negat. value
+
         # TODO: Use maximum duration instead of BIG
         constraint_2b = create_equation(f'{label_prefix}_constraint_2b', self, eq_type='ineq')
         constraint_2b.add_summand(duration_in_hours, -1, time_indices[1:])  # duration(t)

--- a/flixOpt/features.py
+++ b/flixOpt/features.py
@@ -426,11 +426,11 @@ class OnOffModel(ElementModel):
         eq_initial_switch.add_constant(-1 * self.on.previous_values[-1])  # On(t-1)
 
         ## Entweder SwitchOff oder SwitchOn
-        # eq: SwitchOn(t) + SwitchOff(t) <= 1
+        # eq: SwitchOn(t) + SwitchOff(t) <= 1.1
         eq_switch_on_or_off = create_equation('Switch_On_or_Off', self, eq_type='ineq')
         eq_switch_on_or_off.add_summand(self.switch_on, 1)
         eq_switch_on_or_off.add_summand(self.switch_off, 1)
-        eq_switch_on_or_off.add_constant(1)
+        eq_switch_on_or_off.add_constant(1.1)
 
         ## Anzahl Starts:
         # eq: nrSwitchOn = sum(SwitchOn(t))

--- a/flixOpt/features.py
+++ b/flixOpt/features.py
@@ -386,7 +386,10 @@ class OnOffModel(ElementModel):
             # Note: (previous values before t=1 are not recognised!)
             # eq: duration(t) >= minimum_duration(t) * [On(t) - On(t+1)] for t=1..(n-1)
             # eq: -duration(t) + minimum_duration(t) * On(t) - minimum_duration(t) * On(t+1) <= 0
-            minimum_duration_used = minimum_duration.active_data[0:-1] # only checked for t=1...(n-1)
+            if minimum_duration.is_scalar:
+                minimum_duration_used = minimum_duration.active_data
+            else:
+                minimum_duration_used = minimum_duration.active_data[0:-1]  # only checked for t=1...(n-1)
             eq_min_duration = create_equation(f'{label_prefix}_minimum_duration', self, eq_type='ineq')
             eq_min_duration.add_summand(duration_in_hours, -1, time_indices[0:-1])  # -duration(t)
             eq_min_duration.add_summand(binary_variable, -1 * minimum_duration_used, time_indices[1:])  # - minimum_duration (t) * On(t+1)

--- a/flixOpt/features.py
+++ b/flixOpt/features.py
@@ -304,6 +304,8 @@ class OnOffModel(ElementModel):
         """
         creates duration variable and adds constraints to a time-series variable to enforce duration limits based on
         binary activity.
+        The minimum duration in the last time step is not restricted.
+        Previous values before t=0 are not recognised!
 
         Parameters:
             variable_label (str):
@@ -370,7 +372,6 @@ class OnOffModel(ElementModel):
         #   on(t)=1 -> duration(t)- duration(t-1) >= dt(t)
         #   on(t)=0 -> duration(t)- duration(t-1) >= negat. value
 
-        # TODO: Use maximum duration instead of BIG
         constraint_2b = create_equation(f'{label_prefix}_constraint_2b', self, eq_type='ineq')
         constraint_2b.add_summand(duration_in_hours, -1, time_indices[1:])  # duration(t)
         constraint_2b.add_summand(duration_in_hours, 1, time_indices[0:-1])  # duration(t-1)
@@ -378,15 +379,18 @@ class OnOffModel(ElementModel):
         constraint_2b.add_constant(-1 * system_model.dt_in_hours[1:] + mega)  # dt(t)
 
         # 3) check minimum_duration before switchOff-step
-        # (last on-time period of timeseries is not checked and can be shorter)
+
         if minimum_duration is not None:
-            # eq: minimum_duration * -1 * [On(t)-On(t-1)] <= duration(t-1)
-            # eq: -duration(t - 1) - minimum_duration * On(t) + minimum_duration * On(t - 1) <= 0
-            # Note: switchOff-step is when: On(t)-On(t-1) == -1
+            # Note: switchOff-step is when: On(t) - On(t+1) == 1
+            # Note: (last on-time period (with last timestep of period t=n) is not checked and can be shorter)
+            # Note: (previous values before t=1 are not recognised!)
+            # eq: duration(t) >= minimum_duration(t) * [On(t) - On(t+1)] for t=1..(n-1)
+            # eq: -duration(t) + minimum_duration(t) * On(t) - minimum_duration(t) * On(t+1) <= 0
+            minimum_duration_used = minimum_duration.active_data[0:-1] # only checked for t=1...(n-1)
             eq_min_duration = create_equation(f'{label_prefix}_minimum_duration', self, eq_type='ineq')
-            eq_min_duration.add_summand(duration_in_hours, -1, time_indices[0:-1])  # duration(t-1)
-            eq_min_duration.add_summand(binary_variable, -1 * minimum_duration.active_data, time_indices[1:])  # on(t)
-            eq_min_duration.add_summand(binary_variable, minimum_duration.active_data, time_indices[0:-1])  # on(t-1)
+            eq_min_duration.add_summand(duration_in_hours, -1, time_indices[0:-1])  # -duration(t)
+            eq_min_duration.add_summand(binary_variable, -1 * minimum_duration_used, time_indices[1:])  # - minimum_duration (t) * On(t+1)
+            eq_min_duration.add_summand(binary_variable, minimum_duration_used, time_indices[0:-1])  # minimum_duration * On(t)
 
         # 4) first index:
         # eq: duration(t=0)= dt(0) * On(0)

--- a/flixOpt/flow_system.py
+++ b/flixOpt/flow_system.py
@@ -23,17 +23,24 @@ class FlowSystem:
     """
     def __init__(self,
                  time_series: np.ndarray[np.datetime64],
-                 last_time_step_hours: Optional[Union[int, float]] = None):
+                 last_time_step_hours: Optional[Union[int, float]] = None,
+                 previous_dt_in_hours: Optional[Union[int, float, np.ndarray]] = None):
         """
-          Parameters
-          ----------
-          time_series : np.ndarray of datetime64
-              timeseries of the data. Must be in datetime64 format. Don't use precisions below 'us'. !np.datetime64[ns]!
-          last_time_step_hours :
-              The duration of last time step.
-              Storages needs this time-duration for calculation of charge state
-              after last time step.
-              If None, then last time increment of time_series is used.
+        Parameters
+        ----------
+        time_series : np.ndarray of datetime64
+            timeseries of the data. Must be in datetime64 format. Don't use precisions below 'us'. !np.datetime64[ns]!
+        last_time_step_hours :
+            The duration of last time step.
+            Storages needs this time-duration for calculation of charge state
+            after last time step.
+            If None, then last time increment of time_series is used.
+        previous_dt_in_hours : Union[int, float, np.ndarray]
+            The duration of previous time steps.
+            If None, the first time increment of time_series is used.
+            This is needed to calculate previous durations (for example consecutive_on_hours).
+            If you use an array, take care that its long enough to cover all previous values!
+
         """
         self.time_series = time_series if isinstance(time_series, np.ndarray) else np.array(time_series)
         if self.time_series.dtype == np.dtype('datetime64[ns]'):
@@ -41,6 +48,9 @@ class FlowSystem:
 
         self.last_time_step_hours = self.time_series[-1] - self.time_series[-2] if last_time_step_hours is None else last_time_step_hours
         self.time_series_with_end = np.append(self.time_series, self.time_series[-1] + self.last_time_step_hours)
+        self.previous_dt_in_hours: Union[int, float, np.ndarray] = (
+                (self.time_series[1] - self.time_series[0]) / np.timedelta64(1, 'h')) \
+                if previous_dt_in_hours is None else previous_dt_in_hours
 
         utils.check_time_series('time series of FlowSystem', self.time_series_with_end)
 

--- a/flixOpt/interface.py
+++ b/flixOpt/interface.py
@@ -8,15 +8,15 @@ from typing import Union, Optional, Dict, List, Tuple, TYPE_CHECKING
 
 from .core import Numeric, Skalar, Numeric_TS
 from .config import CONFIG
-from .structure import get_object_infos_as_str, get_object_infos_as_dict
+from .structure import Interface, Element
+
 if TYPE_CHECKING:
-    from .structure import Element
     from .effects import EffectTimeSeries, EffectValues, EffectValuesInvest
 
 logger = logging.getLogger('flixOpt')
 
 
-class InvestParameters:
+class InvestParameters(Interface):
     """
     collects arguments for invest-stuff
     """
@@ -73,15 +73,12 @@ class InvestParameters:
         self.effects_in_segments = effects_in_segments
         self._minimum_size = minimum_size
         self._maximum_size = maximum_size or CONFIG.modeling.BIG  # default maximum
-    
+
     def transform_data(self):
         from .effects import as_effect_dict
         self.fix_effects = as_effect_dict(self.fix_effects)
         self.divest_effects = as_effect_dict(self.divest_effects)
         self.specific_effects = as_effect_dict(self.specific_effects)
-
-    def infos(self) -> Dict:
-        return get_object_infos_as_dict(self)
 
     @property
     def minimum_size(self):
@@ -91,14 +88,8 @@ class InvestParameters:
     def maximum_size(self):
         return self.fixed_size or self._maximum_size
 
-    def __repr__(self):
-        return f"<{self.__class__.__name__}>: {self.__dict__}"
 
-    def __str__(self):
-        return get_object_infos_as_str(self)
-
-
-class OnOffParameters:
+class OnOffParameters(Interface):
     def __init__(self,
                  effects_per_switch_on: Union[Dict, Numeric] = None,
                  effects_per_running_hour: Union[Dict, Numeric] = None,
@@ -161,12 +152,6 @@ class OnOffParameters:
         self.consecutive_on_hours_max = _create_time_series('consecutive_on_hours_max', self.consecutive_on_hours_max, owner)
         self.consecutive_off_hours_min = _create_time_series('consecutive_off_hours_min', self.consecutive_off_hours_min, owner)
         self.consecutive_off_hours_max = _create_time_series('consecutive_off_hours_max', self.consecutive_off_hours_max, owner)
-
-    def infos(self) -> Dict:
-        return get_object_infos_as_dict(self)
-
-    def __str__(self):
-        return get_object_infos_as_str(self)
 
     @property
     def use_off(self) -> bool:

--- a/flixOpt/structure.py
+++ b/flixOpt/structure.py
@@ -37,6 +37,7 @@ class SystemModel(MathModel):
         # Zeitdaten generieren:
         self.time_series, self.time_series_with_end, self.dt_in_hours, self.dt_in_hours_total = (
             flow_system.get_time_data_from_indices(time_indices))
+        self.previous_dt_in_hours = flow_system.previous_dt_in_hours
         self.nr_of_time_steps = len(self.time_series)
         self.indices = range(self.nr_of_time_steps)
 

--- a/flixOpt/structure.py
+++ b/flixOpt/structure.py
@@ -4,11 +4,15 @@ These classes are not directly used by the end user, but are used by other modul
 """
 
 from typing import List, Dict, Union, Optional, Literal, TYPE_CHECKING, Any
+from copy import deepcopy
 import logging
 import inspect
-import textwrap
+from io import StringIO
+from datetime import datetime
 
 import numpy as np
+from rich.console import Console
+from rich.pretty import Pretty
 
 from . import utils
 from .math_modeling import MathModel, Variable, Equation, Inequation, VariableTS, Solver
@@ -48,8 +52,8 @@ class SystemModel(MathModel):
 
     def do_modeling(self):
         self.effect_collection_model.do_modeling(self)
-        self.component_models = [component.create_model() for component in self.flow_system.components]
-        self.bus_models = [bus.create_model() for bus in self.flow_system.all_buses]
+        self.component_models = [component.create_model() for component in self.flow_system.components.values()]
+        self.bus_models = [bus.create_model() for bus in self.flow_system.buses.values()]
         for component_model in self.component_models:
             component_model.do_modeling(self)
         for bus_model in self.bus_models:  # Buses after Components, because FlowModels are created in ComponentModels
@@ -101,19 +105,19 @@ class SystemModel(MathModel):
         logger.info(f'{" End of Main Results ":#^80}')
 
     def description_of_variables(self, structured: bool = True) -> Dict[str, Union[str, List[str]]]:
-        return {'Components': {comp.label: comp.model.description_of_variables(structured)
-                               for comp in self.flow_system.components},
-                'Buses': {bus.label: bus.model.description_of_variables(structured)
-                          for bus in self.flow_system.all_buses},
+        return {'Components': {label: comp.model.description_of_variables(structured)
+                               for label, comp in self.flow_system.components.items()},
+                'Buses': {label: bus.model.description_of_variables(structured)
+                          for label,bus in self.flow_system.buses.items()},
                 'Effects': self.flow_system.effect_collection.model.description_of_variables(structured),
                 'Others': {model.element.label: model.description_of_variables(structured)
                            for model in self.other_models}}
 
     def description_of_constraints(self, structured: bool = True) -> Dict[str, Union[str, List[str]]]:
-        return {'Components': {comp.label: comp.model.description_of_constraints(structured)
-                               for comp in self.flow_system.components},
-                'Buses': {bus.label: bus.model.description_of_constraints(structured)
-                          for bus in self.flow_system.all_buses},
+        return {'Components': {label: comp.model.description_of_constraints(structured)
+                               for label, comp in self.flow_system.components.items()},
+                'Buses': {label: bus.model.description_of_constraints(structured)
+                          for label, bus in self.flow_system.buses.items()},
                 'Objective': self.objective.description(),
                 'Effects': self.flow_system.effect_collection.model.description_of_constraints(structured),
                 'Others': {model.element.label: model.description_of_constraints(structured)
@@ -134,7 +138,7 @@ class SystemModel(MathModel):
         main_results = {}
         effect_results = {}
         main_results['Effects'] = effect_results
-        for effect in self.flow_system.effect_collection.effects:
+        for effect in self.flow_system.effect_collection.effects.values():
             effect_results[f'{effect.label} [{effect.unit}]'] = {
                 'operation': float(effect.model.operation.sum.result),
                 'invest': float(effect.model.invest.sum.result),
@@ -144,7 +148,7 @@ class SystemModel(MathModel):
         main_results['lower bound'] = self.solver.best_bound
         buses_with_excess = []
         main_results['buses with excess'] = buses_with_excess
-        for bus in self.flow_system.all_buses:
+        for bus in self.flow_system.buses.values():
             if bus.with_excess:
                 if np.sum(bus.model.excess_input.result) > 1e-3 or np.sum(bus.model.excess_output.result) > 1e-3:
                     buses_with_excess.append(bus.label)
@@ -226,7 +230,68 @@ class SystemModel(MathModel):
         return self.effect_collection_model.objective
 
 
-class Element:
+class Interface:
+    """
+    This class is used to collect arguments about a Model.
+    """
+
+    def transform_data(self):
+        raise NotImplementedError(f'Every Interface needs a transform_data() method')
+
+    def infos(self, use_numpy=True, use_element_label=False) -> Dict:
+        """
+        Generate a dictionary representation of the object's constructor arguments.
+        Excludes default values and empty dictionaries and lists.
+        Converts data to be compatible with JSON.
+
+        Parameters:
+        -----------
+        use_numpy bool:
+            Whether to convert NumPy arrays to lists. Defaults to True.
+            If True, numeric numpy arrays (`np.ndarray`) are preserved as-is.
+            If False, they are converted to lists.
+        use_element_label bool:
+            Whether to use the element label instead of the infos of the element. Defaults to False.
+            Note that Elements used as keys in dictionaries are always converted to their labels.
+
+        Returns:
+            Dict: A dictionary representation of the object's constructor arguments.
+
+        """
+        # Get the constructor arguments and their default values
+        init_params = sorted(
+            inspect.signature(self.__init__).parameters.items(),
+            key=lambda x: (x[0].lower() != 'label', x[0].lower())  # Prioritize 'label'
+        )
+        # Build a dict of attribute=value pairs, excluding defaults
+        details = {'class': ':'.join([cls.__name__ for cls in self.__class__.__mro__])}
+        for name, param in init_params:
+            if name == 'self':
+                continue
+            value, default = getattr(self, name, None), param.default
+            # Ignore default values and empty dicts and list
+            if np.all(value == default) or (isinstance(value, (dict, list)) and not value):
+                continue
+            details[name] = copy_and_convert_datatypes(value, use_numpy, use_element_label)
+        return details
+
+    def __repr__(self):
+        # Get the constructor arguments and their current values
+        init_signature = inspect.signature(self.__init__)
+        init_args = init_signature.parameters
+
+        # Create a dictionary with argument names and their values
+        args_str = ', '.join(
+            f"{name}={repr(getattr(self, name, None))}"
+            for name in init_args if name != 'self'
+        )
+        return f"{self.__class__.__name__}({args_str})"
+
+    def __str__(self):
+        return get_str_representation(self.infos(use_numpy=True, use_element_label=True))
+
+
+class Element(Interface):
     """ Basic Element of flixOpt"""
 
     def __init__(self, label: str, meta_data: Dict = None):
@@ -250,30 +315,8 @@ class Element:
         """ This function is used to do some basic plausibility checks for each Element during initialization """
         raise NotImplementedError(f'Every Element needs a _plausibility_checks() method')
 
-    def transform_data(self) -> None:
-        """ This function is used to transform the time series data from the User to proper TimeSeries Objects """
-        raise NotImplementedError(f'Every Element needs a transform_data() method')
-
     def create_model(self) -> None:
         raise NotImplementedError(f'Every Element needs a create_model() method')
-
-    def __repr__(self):
-        # Get the constructor arguments and their current values
-        init_signature = inspect.signature(self.__init__)
-        init_args = init_signature.parameters
-
-        # Create a dictionary with argument names and their values
-        args_str = ', '.join(
-            f"{name}={repr(getattr(self, name, None))}"
-            for name in init_args if name != 'self'
-        )
-        return f"{self.__class__.__name__}({args_str})"
-
-    def __str__(self):
-        return get_object_infos_as_str(self)
-
-    def infos(self) -> Dict:
-        return get_object_infos_as_dict(self)
 
     @property
     def label_full(self) -> str:
@@ -460,150 +503,148 @@ def create_variable(label: str,
     return var
 
 
-def get_object_infos_as_str(obj) -> str:
+def copy_and_convert_datatypes(data: Any,
+                               use_numpy: bool = True,
+                               use_element_label: bool = False) -> Any:
     """
-    Returns a string representation of an object's constructor arguments,
-    excluding default values. Formats dictionaries with nested child class objects, displaying their labels.
+    Converts values in a nested data structure into JSON-compatible types while preserving or transforming numpy arrays
+    and custom `Element` objects based on the specified options.
+
+    The function handles various data types and transforms them into a consistent, readable format:
+    - Primitive types (`int`, `float`, `str`, `bool`, `None`) are returned as-is.
+    - Numpy scalars are converted to their corresponding Python scalar types.
+    - Collections (`list`, `tuple`, `set`, `dict`) are recursively processed to ensure all elements are compatible.
+    - Numpy arrays are preserved or converted to lists, depending on `use_numpy`.
+    - Custom `Element` objects can be represented either by their `label` or their initialization parameters as a dictionary.
+    - Timestamps (`datetime`) are converted to ISO 8601 strings.
+
+    Parameters
+    ----------
+    data : Any
+        The input data to process, which may be deeply nested and contain a mix of types.
+    use_numpy : bool, optional
+        If `True`, numeric numpy arrays (`np.ndarray`) are preserved as-is. If `False`, they are converted to lists.
+        Default is `True`.
+    use_element_label : bool, optional
+        If `True`, `Element` objects are represented by their `label`. If `False`, they are converted into a dictionary
+        based on their initialization parameters. Default is `False`.
+
+    Returns
+    -------
+    Any
+        A transformed version of the input data, containing only JSON-compatible types:
+        - `int`, `float`, `str`, `bool`, `None`
+        - `list`, `dict`
+        - `np.ndarray` (if `use_numpy=True`. This is NOT JSON-compatible)
+
+    Raises
+    ------
+    TypeError
+        If the data cannot be converted to the specified types.
+
+    Examples
+    --------
+    >>> copy_and_convert_datatypes({"a": np.array([1, 2, 3]), "b": Element(label="example")})
+    {'a': array([1, 2, 3]), 'b': {'class': 'Element', 'label': 'example'}}
+
+    >>> copy_and_convert_datatypes({"a": np.array([1, 2, 3]), "b": Element(label="example")}, use_numpy=False)
+    {'a': [1, 2, 3], 'b': {'class': 'Element', 'label': 'example'}}
+
+    Notes
+    -----
+    - The function gracefully handles unexpected types by issuing a warning and returning a deep copy of the data.
+    - Empty collections (lists, dictionaries) and default parameter values in `Element` objects are omitted from the output.
+    - Numpy arrays with non-numeric data types are automatically converted to lists.
+    """
+    if isinstance(data, (int, float, str, bool, type(None))):
+        return data
+    elif isinstance(data, datetime):
+        return data.isoformat()
+
+    elif isinstance(data, np.integer):
+        return int(data)
+    elif isinstance(data, np.floating):
+        return float(data)
+    elif isinstance(data, (np.generic,)):  # For any numpy scalar types
+        return data.item()
+
+    elif isinstance(data, (tuple, set)):
+        return copy_and_convert_datatypes([item for item in data], use_numpy)
+    elif isinstance(data, dict):
+        return {copy_and_convert_datatypes(key, use_numpy, use_element_label=True):
+                    copy_and_convert_datatypes(value, use_numpy, use_element_label) for key, value in data.items()}
+    elif isinstance(data, list):  # Shorten arrays/lists to be readable
+        if use_numpy and all([isinstance(value, (int, float)) for value in data]):
+            return np.array([item for item in data])
+        else:
+            return [copy_and_convert_datatypes(item, use_numpy, use_element_label) for item in data]
+
+    elif isinstance(data, np.ndarray):
+        if not use_numpy:
+            return copy_and_convert_datatypes(data.tolist(), use_numpy, use_element_label)
+        elif use_numpy and np.issubdtype(data.dtype, np.number):
+            return data
+        else:
+            logger.critical(f'An np.array with non-numeric content was found: {data=}.'
+                           f'It will be converted to a list instead')
+            return copy_and_convert_datatypes(data.tolist(), use_numpy, use_element_label)
+
+    elif isinstance(data, TimeSeries):
+        return copy_and_convert_datatypes(data.active_data, use_numpy, use_element_label)
+    elif isinstance(data, TimeSeriesData):
+        return copy_and_convert_datatypes(data.data, use_numpy, use_element_label)
+
+    elif isinstance(data, Interface):
+        if use_element_label and isinstance(data, Element):
+            return data.label
+        return data.infos(use_numpy, use_element_label)
+    else:
+        raise TypeError(f'copy_and_convert_datatypes() did get unexpected data of type "{type(data)}": {data=}')
+
+def get_str_representation(data: Any, array_length: int = 50, precision: int = 2) -> str:
+    """
+    Generate a string representation of deeply nested data using `rich.print`.
+    NumPy arrays are shortened to the specified length and converted to strings.
 
     Args:
-        obj: The object whose constructor arguments will be formatted and returned as a string.
+        data (Any): The data to format and represent.
+        array_length (int): Maximum length of NumPy arrays to display. Longer arrays are truncated.
+        precision (int): Number of decimal places to display for floats in numerical arrays.
 
     Returns:
-        str: A string representation of the object's constructor arguments,
-             with properly formatted dictionaries, and nested objects' labels.
+        str: The formatted string representation of the data.
     """
 
-    def numeric_as_str(item: Union[Numeric, TimeSeries, TimeSeriesData], max_length: int = 100) -> str:
-        """
-        Returns a short oneline string of numeric data.
-        If something else than the expected datatypes is passes, it returns the item aas a str
-        """
-        if isinstance(item, TimeSeries):
-            item = item.active_data
-        elif isinstance(item, TimeSeriesData):
-            item = item.data
-
-        if isinstance(item, np.ndarray):
-            text = str(item).replace('\n', '')
-            if len(text) > max_length:
-                return text[:max_length-3]+'...'
-            else:
-                return text
-        elif isinstance(item, (Skalar, np.integer, np.floating)):
-            return str(item)
+    def format_np_array_if_found(value: Any) -> Any:
+        """Recursively processes the data, formatting NumPy arrays."""
+        if isinstance(value, (int, float, str, bool, type(None))):
+            return value
+        elif isinstance(value, np.ndarray):
+            return shorten_np_array(value)
+        elif isinstance(value, dict):
+            return {format_np_array_if_found(k): format_np_array_if_found(v) for k, v in value.items()}
+        elif isinstance(value, (list, tuple, set)):
+            return [format_np_array_if_found(v) for v in value]
         else:
-            raise TypeError(f' Wrong type passed to function numeric_as_str(): {type(item)}')
+            logger.warning(f'Unexpected value found when trying to format numpy array numpy array: {type(value)=}; {value=}')
+            return value
 
-    def dict_as_str(d: Dict, current_indent_level: int = 1, indent_depth: int = 3) -> str:
-        """
-        Recursively formats a dictionary, skipping {None: some_value} dictionaries by returning only the value.
-
-        Args:
-            d (dict): The dictionary to format.
-            current_indent_level (int): The current indentation level (default is 1).
-            indent_depth (int): The number of spaces per indent (default is 3).
-
-        Returns:
-            str: A string representation of the dictionary with the keys' labels and appropriate indentation.
-        """
-        # If the dictionary has a single {None: value} entry, return the value directly
-        if len(d) == 1 and None in d:
-            return str(d[None])
-
-        formatted_items = []
-        for k, v in d.items():
-            key_str = k.label if hasattr(k, 'label') else str(k)  # Use labels instead of __str__ if availlable
-            if isinstance(v, dict):
-                v_str = dict_as_str(v, current_indent_level + 1)  # Recursively format nested dictionaries
-            else:
-                v_str = item_as_str(v)
-            formatted_items.append(f"{key_str}: {v_str}")
-        return '{\n' + textwrap.indent(",\n".join(formatted_items), ' ' * current_indent_level * indent_depth) + '}'
-
-    def item_as_str(item: Any, indent_level: int = 1, indent_depth: int = 3) -> str:
-        """ Convert Any item to a string"""
-        if isinstance(item, dict):
-            return dict_as_str(item, indent_level, indent_depth)  # Recursively format nested dictionaries
-        elif isinstance(item, (Numeric, TimeSeries, TimeSeriesData)):
-            return numeric_as_str(item)  # Special formatting for numerical data
+    def shorten_np_array(arr: np.ndarray) -> str:
+        """Shortens NumPy arrays if they exceed the specified length."""
+        if arr.size > array_length:  # Calculate basic statistics
+            return (f"Array (min={np.min(arr):.2f}, max={np.max(arr):.2f}, mean={np.mean(arr):.2f}, "
+                    f"median={np.median(arr):.2f}, std={np.std(arr):.2f}, length={len(arr)})")
         else:
-            return str(item)  # All others as str
+            return np.array2string(arr[:array_length],
+                                        precision=precision,
+                                        max_line_width=1000,
+                                        separator=', ')
 
-    # Get the constructor arguments and their default values
-    init_params = sorted(inspect.signature(obj.__init__).parameters.items(),
-                         key=lambda x: (x[0].lower() != 'label', x[0].lower()))
+    # Process the data to handle NumPy arrays
+    formatted_data = format_np_array_if_found(copy_and_convert_datatypes(data, use_numpy=True))
 
-    # Build a list of attribute=value pairs, excluding defaults
-    details = []
-    for name, param in init_params:
-        if name == 'self':
-            continue
-        value, default = getattr(obj, name, None), param.default
-
-        if isinstance(value, (dict, list)) and not value:  # Ignore empty dicts and lists
-            pass
-        elif np.all(value == default):  # Ignore default values
-            pass
-        else:
-            details.append(f"{name}={item_as_str(value)}")  # Formatted numeric-string
-
-    # Join all relevant parts and format them in the output
-    full_str = ',\n'.join(details)
-    return f"{obj.__class__.__name__}(\n{textwrap.indent(full_str, ' '*3)})"
-
-
-def get_object_infos_as_dict(obj) -> Dict[str, Optional[Union[int, float, str, bool, list, dict]]]:
-    """
-    Returns a dictionary representation of an object's constructor arguments,
-    excluding default values. Formats dictionaries with nested child class objects, displaying their labels.
-    Converts data to python native objects. Further, converts Tuples to Lists.
-
-    Args:
-        obj: The object whose constructor arguments will be formatted and returned as a dictionary.
-
-    Returns:
-        dict: A dictionary representation of the object's constructor arguments,
-              with properly formatted dictionaries and nested objects' labels.
-    """
-
-    def format_dict(d: Dict[Any, Any]) -> Dict[str, Optional[Union[int, float, str, bool, Dict, List]]]:
-        """ Recursively converts datatypes in a dictionary. Converts keys to string """
-        return {k.label if hasattr(k, 'label') else str(k): format_item(v) for k, v in d.items()}
-
-    def format_item(item: Any) -> Optional[Union[int, float, str, bool, List, Dict]]:
-        """ Convert any item to a format that is usable by json and yaml"""
-        if isinstance(item, (int, float, str, bool, type(None), np.integer, np.floating, np.ndarray)):
-            return utils.convert_to_native_types(item)
-        elif isinstance(item, (tuple, list)):
-            return [format_item(i) for i in item]
-        elif isinstance(item, dict):  # Format dictionaries with custom formatting
-            if len(item) == 1 and None in item:
-                return format_item(item[None])
-            else:
-                return format_dict(item)
-        elif isinstance(item, TimeSeries):
-            return format_item(item.active_data)
-        elif isinstance(item, TimeSeriesData):
-            return format_item(item.data)
-        elif hasattr(item, 'infos') and callable(getattr(item, 'infos')):
-            return item.infos()
-        else:
-            raise TypeError(f'Unexpected type passed to function format_item(). {type(item)=}; {item=}')
-
-    init_params = sorted(inspect.signature(obj.__init__).parameters.items(),
-                         key=lambda x: (x[0].lower() != 'label', x[0].lower()))
-
-    # Build a dict of attribute=value pairs, excluding defaults
-    details = {'class': ':'.join([cls.__name__ for cls in obj.__class__.__mro__])}
-    for name, param in init_params:
-        if name == 'self':
-            continue
-        value, default = getattr(obj, name, None), param.default
-        if isinstance(value, (dict, list)) and not value:  # Ignore empty dicts and lists
-            pass
-        elif np.all(value == default):  # Ignore default values
-            pass
-        else:
-            details[name] = format_item(value)
-
-    return details
+    # Use Rich to format and print the data
+    with StringIO() as output_buffer:
+        console = Console(file=output_buffer, width=1000)  # Adjust width as needed
+        console.print(Pretty(formatted_data, expand_all=True, indent_guides=True))
+        return output_buffer.getvalue()

--- a/flixOpt/utils.py
+++ b/flixOpt/utils.py
@@ -84,35 +84,11 @@ def apply_formating(data_dict: Dict[str, Union[int, float]],
 
 
 def label_is_valid(label: str) -> bool:
-    """ Function to make shure '__' is reserved for internal splitting of labels"""
+    """ Function to make sure '__' is reserved for internal splitting of labels"""
     if label.startswith('_') or label.endswith('_') or '__' in label:
         return False
     return True
 
-
-def convert_to_native_types(value: Optional[Union[int, float, str, list, tuple, dict, np.ndarray, datetime]]
-                            ) -> Optional[Union[int, float, str, list, dict]]:
-    """ Recursively converts datatypes from a nested structure. Makes types compatible with yaml and json."""
-    if isinstance(value, np.floating):
-        return float(value)
-    elif isinstance(value, np.integer):
-        return int(value)
-    elif isinstance(value, np.ndarray):
-        return [convert_to_native_types(item) for item in value.tolist()]
-    elif isinstance(value, (np.generic,)):  # For any numpy scalar types
-        return value.item()
-
-    elif isinstance(value, (int, float, str, bool, type(None))):  # After numpy checks!!!
-        return value
-    elif isinstance(value, (list, tuple)):
-        return [convert_to_native_types(item) for item in value]
-    elif isinstance(value, dict):
-        return {convert_to_native_types(k): convert_to_native_types(v) for k, v in value.items()}
-
-    elif isinstance(value, datetime):
-        return value.isoformat()
-    else:
-        raise TypeError(f'Type {type(value)} is not supported in convert_to_native_types().')
 
 def convert_numeric_lists_to_arrays(d: Union[Dict[str, Any], List[Any], tuple]) -> Union[Dict[str, Any], List[Any], tuple]:
     """

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -367,7 +367,7 @@ class TestComplex(BaseTest):
         aGaskessel = Boiler('Kessel', eta=0.5, on_off_parameters=OnOffParameters(effects_per_running_hour={costs: 0, CO2: 1000}),
                             Q_th=Flow('Q_th', bus=Fernwaerme, load_factor_max=1.0, load_factor_min=0.1, relative_minimum=5 / 50, relative_maximum=1, previous_flow_rate=50,
                                       size=InvestParameters(fix_effects=1000, fixed_size=50, optional=False, specific_effects={costs: 10, PE: 2}),
-                                      can_be_off=OnOffParameters(on_hours_total_min=0, on_hours_total_max=1000, consecutive_on_hours_max=10, consecutive_off_hours_max=10, effects_per_switch_on=0.01, switch_on_total_max=1000),
+                                      can_be_off=OnOffParameters(on_hours_total_min=0, on_hours_total_max=1000, consecutive_on_hours_max=10, consecutive_on_hours_min =1,consecutive_off_hours_max=10, effects_per_switch_on=0.01, switch_on_total_max=1000),
                                       flow_hours_total_max=1e6),
                             Q_fu=Flow('Q_fu', bus=Gas, size=200, relative_minimum=0, relative_maximum=1))
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -48,8 +48,8 @@ class TestSimple(BaseTest):
 
     def test_model(self):
         calculation = self.model()
-        effects = {effect.label: effect for effect in calculation.flow_system.effect_collection.effects}
-        comps = {comp.label: comp for comp in calculation.flow_system.components}
+        effects = calculation.flow_system.effect_collection.effects
+        comps = calculation.flow_system.components
 
         # Compare expected values with actual values
         self.assertAlmostEqualNumeric(effects['costs'].model.all.sum.result, 81.88394666666667,
@@ -81,7 +81,7 @@ class TestSimple(BaseTest):
                                   "Q_th doesnt match expected value")
 
         df = results.to_dataframe('Fernwärme', with_last_time_step=False)
-        comps = {comp.label: comp for comp in calculation.flow_system.components}
+        comps = calculation.flow_system.components
         self.assertAlmostEqualNumeric(comps['Wärmelast'].sink.model.flow_rate.result,
                                       df['Wärmelast__Q_th_Last'],
                                       "Loaded Results and directly used results dont match, or loading didnt work properly")
@@ -258,8 +258,8 @@ class TestComplex(BaseTest):
 
     def test_basic(self):
         calculation = self.basic_model()
-        effects = {effect.label: effect for effect in calculation.flow_system.effect_collection.effects}
-        comps = {comp.label: comp for comp in calculation.flow_system.components}
+        effects = calculation.flow_system.effect_collection.effects
+        comps = calculation.flow_system.components
 
         # Compare expected values with actual values
         self.assertAlmostEqualNumeric(effects['costs'].model.all.sum.result, -11597.873624489237,
@@ -323,8 +323,8 @@ class TestComplex(BaseTest):
 
     def test_segments_of_flows(self):
         calculation = self.segments_of_flows_model()
-        effects = {effect.label: effect for effect in calculation.flow_system.effect_collection.effects}
-        comps = {comp.label: comp for comp in calculation.flow_system.components}
+        effects = calculation.flow_system.effect_collection.effects
+        comps = calculation.flow_system.components
 
         # Compare expected values with actual values
         self.assertAlmostEqualNumeric(effects['costs'].model.all.sum.result, -10710.997365760755,
@@ -456,13 +456,13 @@ class TestModelingTypes(BaseTest):
 
     def test_full(self):
         calculation = self.calculate("full")
-        effects = {effect.label: effect for effect in calculation.flow_system.effect_collection.effects}
-        comps = {comp.label: comp for comp in calculation.flow_system.components}
+        effects = calculation.flow_system.effect_collection.effects
+        comps = calculation.flow_system.components
         self.assertAlmostEqualNumeric(effects['costs'].model.all.sum.result, 343613, "costs doesnt match expected value")
 
     def test_aggregated(self):
         calculation = self.calculate("aggregated")
-        effects = {effect.label: effect for effect in calculation.flow_system.effect_collection.effects}
+        effects = calculation.flow_system.effect_collection.effects
         self.assertAlmostEqualNumeric(effects['costs'].model.all.sum.result, 342967.0, "costs doesnt match expected value")
 
     def test_segmented(self):


### PR DESCRIPTION
# v1.0.2
## Save results in .zip file
In order to reduce the footprint of a flixOpt calculation, the `results.json` and `data.json` files are now saved in a `results.zip` file.
Directly loading from .json is supported for backwards compatibility.

## Account for previous values in consecutive flow rate bounds
The number of consecutive hours a Flow/Component can be on or off can be restricted in flixOpt.
When optimizing short time windows with long minimum durations, its crucial to take the historical dispatch into account, when creating the bounds for the minimum consecutive duration.
### Example
A Flow that was already operating for 10 hours straight, and has `minimum_consecutive_on_hours = 12`, it can now switch off after an additional 2 hours in operation, instead of having to operate  the full 12 hours in the optimized period.