### PR TITLE
Next/patch

### DIFF
--- a/examples/02_Complex/complex_example.py
+++ b/examples/02_Complex/complex_example.py
@@ -62,7 +62,7 @@ if __name__ == '__main__':
             relative_maximum=1,  # Maximum part load
             previous_flow_rate=50,  # Previous flow rate
             flow_hours_total_max=1e6,  # Total energy flow limit
-            can_be_off=fx.OnOffParameters(
+            on_off_parameters=fx.OnOffParameters(
                 on_hours_total_min=0,  # Minimum operating hours
                 on_hours_total_max=1000,  # Maximum operating hours
                 consecutive_on_hours_max=10,  # Max consecutive operating hours

--- a/examples/03_Calculation_types/example_calculation_types.py
+++ b/examples/03_Calculation_types/example_calculation_types.py
@@ -75,7 +75,7 @@ if __name__ == '__main__':
             size=95,
             relative_minimum=12 / 95,
             previous_flow_rate=20,
-            can_be_off=fx.OnOffParameters(effects_per_switch_on=1000),
+            on_off_parameters=fx.OnOffParameters(effects_per_switch_on=1000),
         ),
     )
 

--- a/flixOpt/elements.py
+++ b/flixOpt/elements.py
@@ -164,7 +164,7 @@ class Flow(Element):
         relative_minimum: Numeric_TS = 0,
         relative_maximum: Numeric_TS = 1,
         effects_per_flow_hour: EffectValues = None,
-        can_be_off: Optional[OnOffParameters] = None,
+        on_off_parameters: Optional[OnOffParameters] = None,
         flow_hours_total_max: Optional[Skalar] = None,
         flow_hours_total_min: Optional[Skalar] = None,
         load_factor_min: Optional[Skalar] = None,
@@ -196,10 +196,10 @@ class Flow(Element):
             maximal load factor (see minimal load factor)
         effects_per_flow_hour : scalar, array, TimeSeriesData, optional
             operational costs, costs per flow-"work"
-        can_be_off : OnOffParameters, optional
-            flow can be "off", i.e. be zero (only relevant if relative_minimum > 0)
-            Then a binary var "on" is used.. Further, several other restrictions and effects can be modeled
-            through this On and Off State (See OnOffParameters)
+        on_off_parameters : OnOffParameters, optional
+            If present, flow can be "off", i.e. be zero (only relevant if relative_minimum > 0)
+            Therefore a binary var "on" is used. Further, several other restrictions and effects can be modeled
+            through this On/Off State (See OnOffParameters)
         flow_hours_total_max : TYPE, optional
             maximum flow-hours ("flow-work")
             (if size is not const, maybe load_factor_max fits better for you!)
@@ -228,7 +228,7 @@ class Flow(Element):
         self.effects_per_flow_hour = effects_per_flow_hour if effects_per_flow_hour is not None else {}
         self.flow_hours_total_max = flow_hours_total_max
         self.flow_hours_total_min = flow_hours_total_min
-        self.on_off_parameters = can_be_off
+        self.on_off_parameters = on_off_parameters
 
         self.previous_flow_rate = previous_flow_rate
 

--- a/flixOpt/structure.py
+++ b/flixOpt/structure.py
@@ -670,10 +670,17 @@ def get_str_representation(data: Any, array_length: int = 50, precision: int = 2
 
     def shorten_np_array(arr: np.ndarray) -> str:
         """Shortens NumPy arrays if they exceed the specified length."""
+        def normalized_center_of_mass(array: Any) -> float:
+            # position in array (0 bis 1 normiert)
+            positions = np.linspace(0, 1, len(array))  # weights w_i
+            # mass center
+            return np.sum(positions * array) / np.sum(array)
+
         if arr.size > array_length:  # Calculate basic statistics
             return (
                 f'Array (min={np.min(arr):.2f}, max={np.max(arr):.2f}, mean={np.mean(arr):.2f}, '
-                f'median={np.median(arr):.2f}, std={np.std(arr):.2f}, length={len(arr)})'
+                f'median={np.median(arr):.2f}, std={np.std(arr):.2f}, len={len(arr)}, '
+                f'center={normalized_center_of_mass(arr):.2f})'
             )
         else:
             return np.array2string(arr[:array_length], precision=precision, max_line_width=1000, separator=', ')
@@ -686,3 +693,6 @@ def get_str_representation(data: Any, array_length: int = 50, precision: int = 2
         console = Console(file=output_buffer, width=1000)  # Adjust width as needed
         console.print(Pretty(formatted_data, expand_all=True, indent_guides=True))
         return output_buffer.getvalue()
+
+
+

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -389,7 +389,7 @@ class TestOnOff(BaseTest):
                 'Boiler',
                 0.5,
                 Q_fu=fx.Flow('Q_fu', bus=self.get_element('Gas')),
-                Q_th=fx.Flow('Q_th', bus=self.get_element('Fernwärme'), size=100, can_be_off=fx.OnOffParameters()),
+                Q_th=fx.Flow('Q_th', bus=self.get_element('Fernwärme'), size=100, on_off_parameters=fx.OnOffParameters()),
             )
         )
 
@@ -431,7 +431,7 @@ class TestOnOff(BaseTest):
                     'Q_th',
                     bus=self.get_element('Fernwärme'),
                     size=100,
-                    can_be_off=fx.OnOffParameters(consecutive_off_hours_max=100),
+                    on_off_parameters=fx.OnOffParameters(consecutive_off_hours_max=100),
                 ),
             )
         )
@@ -481,7 +481,7 @@ class TestOnOff(BaseTest):
                     'Q_th',
                     bus=self.get_element('Fernwärme'),
                     size=100,
-                    can_be_off=fx.OnOffParameters(force_switch_on=True),
+                    on_off_parameters=fx.OnOffParameters(force_switch_on=True),
                 ),
             )
         )
@@ -538,7 +538,7 @@ class TestOnOff(BaseTest):
                     'Q_th',
                     bus=self.get_element('Fernwärme'),
                     size=100,
-                    can_be_off=fx.OnOffParameters(on_hours_total_max=1),
+                    on_off_parameters=fx.OnOffParameters(on_hours_total_max=1),
                 ),
             ),
             fx.linear_converters.Boiler(
@@ -587,7 +587,7 @@ class TestOnOff(BaseTest):
                     'Q_th',
                     bus=self.get_element('Fernwärme'),
                     size=100,
-                    can_be_off=fx.OnOffParameters(on_hours_total_max=2),
+                    on_off_parameters=fx.OnOffParameters(on_hours_total_max=2),
                 ),
             ),
             fx.linear_converters.Boiler(
@@ -598,7 +598,7 @@ class TestOnOff(BaseTest):
                     'Q_th',
                     bus=self.get_element('Fernwärme'),
                     size=100,
-                    can_be_off=fx.OnOffParameters(on_hours_total_min=3),
+                    on_off_parameters=fx.OnOffParameters(on_hours_total_min=3),
                 ),
             ),
         )
@@ -658,7 +658,7 @@ class TestOnOff(BaseTest):
                     'Q_th',
                     bus=self.get_element('Fernwärme'),
                     size=100,
-                    can_be_off=fx.OnOffParameters(consecutive_on_hours_max=2, consecutive_on_hours_min=2),
+                    on_off_parameters=fx.OnOffParameters(consecutive_on_hours_max=2, consecutive_on_hours_min=2),
                 ),
             ),
             fx.linear_converters.Boiler(
@@ -724,7 +724,7 @@ class TestOnOff(BaseTest):
                     bus=self.get_element('Fernwärme'),
                     size=100,
                     previous_flow_rate=np.array([20]),  # Otherwise its Off before the start
-                    can_be_off=fx.OnOffParameters(consecutive_off_hours_max=2, consecutive_off_hours_min=2),
+                    on_off_parameters=fx.OnOffParameters(consecutive_off_hours_max=2, consecutive_off_hours_min=2),
                 ),
             ),
         )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -123,7 +123,7 @@ class TestSimple(BaseTest):
                 size=50,
                 relative_minimum=5 / 50,
                 relative_maximum=1,
-                can_be_off=fx.OnOffParameters(),
+                on_off_parameters=fx.OnOffParameters(),
             ),
             Q_fu=fx.Flow('Q_fu', bus=Gas),
         )
@@ -131,7 +131,7 @@ class TestSimple(BaseTest):
             'CHP_unit',
             eta_th=0.5,
             eta_el=0.4,
-            P_el=fx.Flow('P_el', bus=Strom, size=60, relative_minimum=5 / 60, can_be_off=fx.OnOffParameters()),
+            P_el=fx.Flow('P_el', bus=Strom, size=60, relative_minimum=5 / 60, on_off_parameters=fx.OnOffParameters()),
             Q_th=fx.Flow('Q_th', bus=Fernwaerme),
             Q_fu=fx.Flow('Q_fu', bus=Gas),
         )
@@ -526,7 +526,7 @@ class TestComplex(BaseTest):
                 size=fx.InvestParameters(
                     fix_effects=1000, fixed_size=50, optional=False, specific_effects={costs: 10, PE: 2}
                 ),
-                can_be_off=fx.OnOffParameters(
+                on_off_parameters=fx.OnOffParameters(
                     on_hours_total_min=0,
                     on_hours_total_max=1000,
                     consecutive_on_hours_max=10,
@@ -624,7 +624,7 @@ class TestComplex(BaseTest):
                 load_factor_min=0.1,
                 relative_minimum=5 / 50,
                 relative_maximum=1,
-                can_be_off=fx.OnOffParameters(
+                on_off_parameters=fx.OnOffParameters(
                     on_hours_total_min=0,
                     on_hours_total_max=1000,
                     consecutive_on_hours_max=10,
@@ -775,7 +775,7 @@ class TestModelingTypes(BaseTest):
                 size=95,
                 relative_minimum=12 / 95,
                 previous_flow_rate=0,
-                can_be_off=fx.OnOffParameters(effects_per_switch_on=1000),
+                on_off_parameters=fx.OnOffParameters(effects_per_switch_on=1000),
             ),
         )
         aKWK = fx.linear_converters.CHP(


### PR DESCRIPTION
# v1.0.4
## Backwards incompatible changes
Parameter `can_be_off` of class `Flow` renamed to `on_off_parameters`.
**Fixes:** Information about OnOffParameters missing in data.json and .infos()

## Improve representation of arrays in print()
* Integrated "normed center of mass" in str_representation of array. Dadurch werden [0, 0, 1] von [1, 0, 0] und [0, 1, 0] unterscheidbar.
* `length` gekürzt auf `len`
Arrays in Elements are now printed as:
```python
{'fixed_relative_profile': 'Array (min=0.00, max=110.00, mean=46.67, median=20.00, std=41.10, len=108, center=0.50)'}
```
