### PR TITLE
Make flixOpt work without having the package "tsam" installed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Although flixOpt is in its early stages, it is fully functional and ready for ex
 Install flixOpt directly into your environment using pip. Thanks to [HiGHS](https://github.com/ERGO-Code/HiGHS?tab=readme-ov-file), flixOpt can be used without further setup.
 `pip install git+https://github.com/flixOpt/flixOpt.git`
 
-We recommend installing flixOpt with additional dependencies for visualizing network graphs using pyvis:
-`pip install "flixOpt[visualization] @ git+https://github.com/flixOpt/flixOpt.git"`
+We recommend installing flixOpt with all dependencies, which enables interactive network visualizations by [pyvis](https://github.com/WestHealth/pyvis) and time series aggregation by [tsam](https://github.com/FZJ-IEK3-VSA/tsam).
+`pip install "flixOpt[full] @ git+https://github.com/flixOpt/flixOpt.git"`
 
 ---
 

--- a/flixOpt/aggregation.py
+++ b/flixOpt/aggregation.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
+
 try:
     import tsam.timeseriesaggregation as tsam
     TSAM_AVAILABLE = True

--- a/flixOpt/aggregation.py
+++ b/flixOpt/aggregation.py
@@ -12,7 +12,11 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
-import tsam.timeseriesaggregation as tsam
+try:
+    import tsam.timeseriesaggregation as tsam
+    TSAM_AVAILABLE = True
+except ImportError:
+    TSAM_AVAILABLE = False
 
 from .components import Storage
 from .core import Skalar, TimeSeries, TimeSeriesData
@@ -57,6 +61,9 @@ class Aggregation:
         timeseries: pd.DataFrame
             timeseries of the data with a datetime index
         """
+        if not TSAM_AVAILABLE:
+            raise ImportError("The 'tsam' package is required for clustering functionality. "
+                              "Install it with 'pip install tsam'.")
         self.original_data = copy.deepcopy(original_data)
         self.hours_per_time_step = hours_per_time_step
         self.hours_per_period = hours_per_period

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ dependencies = [
     "PyYAML >= 6.0",
     "Pyomo >= 6.4.2",
     "rich >= 13.0.1",
-    "tsam >= 2.3.1",  # Used for time series aggregation
     "highspy >= 1.5.3",  # Default solver
     "pandas >= 2, < 3",  # Used in post-processing
     "matplotlib >= 3.5.2",  # Used in post-processing
@@ -45,11 +44,14 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest",
-    "ruff"
+    "ruff",
+    "pyvis == 0.3.1",  # Used for visualizing the FLowSystem
+    "tsam >= 2.3.1",  # Used for time series aggregation
 ]
 
-visualization = [
+full = [
     "pyvis == 0.3.1",  # Used for visualizing the FLowSystem
+    "tsam >= 2.3.1",  # Used for time series aggregation
 ]
 
 [project.urls]


### PR DESCRIPTION
 tsam is only needed for aggregation, but its (indirect) dependency "joblib" has an CVE, which can prevent flixOpt from working in certain environments.
 Therefore team will be moved to the