### PR TITLE
Fixes/tests

### DIFF
--- a/flixopt/features.py
+++ b/flixopt/features.py
@@ -90,7 +90,7 @@ class InvestmentModel(Model):
             # share: divest_effects - isInvested * divest_effects
             self._model.effects.add_share_to_effects(
                 name=self.label_of_element,
-                expressions={effect: -self.is_invested * factor + factor for effect, factor in fix_effects.items()},
+                expressions={effect: -self.is_invested * factor + factor for effect, factor in self.parameters.divest_effects.items()},
                 target='invest',
             )
 

--- a/flixopt/features.py
+++ b/flixopt/features.py
@@ -636,6 +636,9 @@ class OnOffModel(Model):
             A binary array (0 and 1) indicating the previous on/off states of the variables.
             Returns `array([0])` if no previous values are available.
         """
+        for arr in previous_values:
+            if isinstance(arr, np.ndarray) and arr.ndim > 1:
+                raise ValueError('Only 1D arrays or None values are supported for previous_values')
 
         if not previous_values or all([val is None for val in previous_values]):
             return np.array([0])

--- a/flixopt/features.py
+++ b/flixopt/features.py
@@ -314,6 +314,7 @@ class OnOffModel(Model):
 
             self.switch_on_nr = self.add(
                 self._model.add_variables(
+                    lower=0,
                     upper=self.parameters.switch_on_total_max
                     if self.parameters.switch_on_total_max is not None
                     else np.inf,

--- a/flixopt/interface.py
+++ b/flixopt/interface.py
@@ -111,7 +111,7 @@ class InvestParameters(Interface):
     def __init__(
         self,
         fixed_size: Optional[Union[int, float]] = None,
-        minimum_size: Union[int, float] = 0,  # TODO: Use EPSILON?
+        minimum_size: Optional[Union[int, float]] = None,
         maximum_size: Optional[Union[int, float]] = None,
         optional: bool = True,  # Investition ist weglassbar
         fix_effects: Optional['EffectValuesUserScalar'] = None,
@@ -141,8 +141,8 @@ class InvestParameters(Interface):
                      ]  # €
                 (Attention: Annualize costs to chosen period!)
                 (Args 'specific_effects' and 'fix_effects' can be used in parallel to Investsizepieces)
-            minimum_size: Min nominal value (only if: size_is_fixed = False).
-            maximum_size: Max nominal value (only if: size_is_fixed = False).
+            minimum_size: Min nominal value (only if: size_is_fixed = False). Defaults to CONFIG.modeling.EPSILON.
+            maximum_size: Max nominal value (only if: size_is_fixed = False). Defaults to CONFIG.modeling.BIG.
         """
         self.fix_effects: EffectValuesUser = fix_effects or {}
         self.divest_effects: EffectValuesUser = divest_effects or {}
@@ -150,8 +150,8 @@ class InvestParameters(Interface):
         self.optional = optional
         self.specific_effects: EffectValuesUser = specific_effects or {}
         self.piecewise_effects = piecewise_effects
-        self._minimum_size = minimum_size
-        self._maximum_size = maximum_size or CONFIG.modeling.BIG  # default maximum
+        self._minimum_size = minimum_size if minimum_size is not None else CONFIG.modeling.EPSILON
+        self._maximum_size = maximum_size if maximum_size is not None else CONFIG.modeling.BIG  # default maximum
 
     def transform_data(self, flow_system: 'FlowSystem'):
         self.fix_effects = flow_system.effects.create_effect_values_dict(self.fix_effects)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,11 +6,11 @@ It helps avoid redundancy and centralizes reusable test logic.
 
 import os
 
+import linopy.testing
 import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
-import linopy.testing
 
 import flixopt as fx
 from flixopt.structure import SystemModel
@@ -455,17 +455,17 @@ def assert_conequal(actual: linopy.Constraint, desired: linopy.Constraint):
     try:
         linopy.testing.assert_linequal(actual.lhs, desired.lhs)
     except AssertionError as e:
-        raise AssertionError(f"{name} left-hand sides don't match:\n{e}")
+        raise AssertionError(f"{name} left-hand sides don't match:\n{e}") from e
 
     try:
         linopy.testing.assert_linequal(actual.rhs, desired.rhs)
     except AssertionError as e:
-        raise AssertionError(f"{name} right-hand sides don't match:\n{e}")
+        raise AssertionError(f"{name} right-hand sides don't match:\n{e}") from e
 
     try:
         xr.testing.assert_equal(actual.sign, desired.sign)
-    except AssertionError:
-        raise AssertionError(f"{name} signs don't match:\nActual: {actual.sign}\nExpected: {desired.sign}")
+    except AssertionError as e:
+        raise AssertionError(f"{name} signs don't match:\nActual: {actual.sign}\nExpected: {desired.sign}") from e
 
 
 def assert_var_equal(actual: linopy.Variable, desired: linopy.Variable):
@@ -473,13 +473,13 @@ def assert_var_equal(actual: linopy.Variable, desired: linopy.Variable):
     name = actual.name
     try:
         xr.testing.assert_equal(actual.lower, desired.lower)
-    except AssertionError:
-        raise AssertionError(f"{name} lower bounds don't match:\nActual: {actual.lower}\nExpected: {desired.lower}")
+    except AssertionError as e:
+        raise AssertionError(f"{name} lower bounds don't match:\nActual: {actual.lower}\nExpected: {desired.lower}") from e
 
     try:
         xr.testing.assert_equal(actual.upper, desired.upper)
-    except AssertionError:
-        raise AssertionError(f"{name} upper bounds don't match:\nActual: {actual.upper}\nExpected: {desired.upper}")
+    except AssertionError as e:
+        raise AssertionError(f"{name} upper bounds don't match:\nActual: {actual.upper}\nExpected: {desired.upper}") from e
 
     if actual.type != desired.type:
         raise AssertionError(f"{name} types don't match: {actual.type} != {desired.type}")
@@ -492,8 +492,8 @@ def assert_var_equal(actual: linopy.Variable, desired: linopy.Variable):
 
     try:
         xr.testing.assert_equal(actual.coords, desired.coords)
-    except AssertionError:
-        raise AssertionError(f"{name} coordinates don't match:\nActual: {actual.coords}\nExpected: {desired.coords}")
+    except AssertionError as e:
+        raise AssertionError(f"{name} coordinates don't match:\nActual: {actual.coords}\nExpected: {desired.coords}") from e
 
     if actual.coord_dims != desired.coord_dims:
         raise AssertionError(f"{name} coordinate dimensions don't match: {actual.coord_dims} != {desired.coord_dims}")

--- a/tests/test_bus.py
+++ b/tests/test_bus.py
@@ -5,7 +5,7 @@ import xarray as xr
 
 import flixopt as fx
 
-from .conftest import basic_flow_system_linopy, create_linopy_model, assert_var_equal, assert_conequal
+from .conftest import assert_conequal, assert_var_equal, create_linopy_model
 
 
 class TestBusModel:

--- a/tests/test_bus.py
+++ b/tests/test_bus.py
@@ -1,0 +1,58 @@
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+import flixopt as fx
+
+from .conftest import basic_flow_system_linopy, create_linopy_model, assert_var_equal, assert_conequal
+
+
+class TestBusModel:
+    """Test the FlowModel class."""
+
+    def test_bus(self, basic_flow_system_linopy):
+        """Test that flow model constraints are correctly generated."""
+        flow_system = basic_flow_system_linopy
+        bus = fx.Bus('TestBus', excess_penalty_per_flow_hour=None)
+        flow_system.add_elements(bus,
+                                 fx.Sink('WärmelastTest', sink=fx.Flow('Q_th_Last', 'TestBus')),
+                                 fx.Source('GastarifTest', source=fx.Flow('Q_Gas', 'TestBus')))
+        model = create_linopy_model(flow_system)
+
+        assert set(bus.model.variables) == {'WärmelastTest(Q_th_Last)|flow_rate', 'GastarifTest(Q_Gas)|flow_rate'}
+        assert set(bus.model.constraints) == {'TestBus|balance'}
+
+        assert_conequal(
+            model.constraints['TestBus|balance'],
+            model.variables['GastarifTest(Q_Gas)|flow_rate'] == model.variables['WärmelastTest(Q_th_Last)|flow_rate']
+        )
+
+    def test_bus_penalty(self, basic_flow_system_linopy):
+        """Test that flow model constraints are correctly generated."""
+        flow_system = basic_flow_system_linopy
+        timesteps = flow_system.time_series_collection.timesteps
+        bus = fx.Bus('TestBus')
+        flow_system.add_elements(bus,
+                                 fx.Sink('WärmelastTest', sink=fx.Flow('Q_th_Last', 'TestBus')),
+                                 fx.Source('GastarifTest', source=fx.Flow('Q_Gas', 'TestBus')))
+        model = create_linopy_model(flow_system)
+
+        assert set(bus.model.variables) == {'TestBus|excess_input',
+                                            'TestBus|excess_output',
+                                            'WärmelastTest(Q_th_Last)|flow_rate',
+                                            'GastarifTest(Q_Gas)|flow_rate'}
+        assert set(bus.model.constraints) == {'TestBus|balance'}
+
+        assert_var_equal(model.variables['TestBus|excess_input'], model.add_variables(lower=0, coords = (timesteps,)))
+        assert_var_equal(model.variables['TestBus|excess_output'], model.add_variables(lower=0, coords=(timesteps,)))
+
+        assert_conequal(
+            model.constraints['TestBus|balance'],
+            model.variables['GastarifTest(Q_Gas)|flow_rate'] - model.variables['WärmelastTest(Q_th_Last)|flow_rate'] + model.variables['TestBus|excess_input'] -  model.variables['TestBus|excess_output'] ==  0
+        )
+
+        assert_conequal(
+            model.constraints['TestBus->Penalty'],
+            model.variables['TestBus->Penalty'] == (model.variables['TestBus|excess_input'] * 1e5 * model.hours_per_step).sum() + (model.variables['TestBus|excess_output'] * 1e5 * model.hours_per_step).sum(),
+        )

--- a/tests/test_effect.py
+++ b/tests/test_effect.py
@@ -1,0 +1,143 @@
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+import flixopt as fx
+
+from .conftest import basic_flow_system_linopy, create_linopy_model, assert_var_equal, assert_conequal
+
+
+class TestBusModel:
+    """Test the FlowModel class."""
+
+    def test_minimal(self, basic_flow_system_linopy):
+        flow_system = basic_flow_system_linopy
+        timesteps = flow_system.time_series_collection.timesteps
+        effect = fx.Effect('Effect1', '€', 'Testing Effect')
+
+        flow_system.add_elements(effect)
+        model = create_linopy_model(flow_system)
+
+        assert set(effect.model.variables) == {'Effect1(invest)|total',
+                                                 'Effect1(operation)|total',
+                                                 'Effect1(operation)|total_per_timestep',
+                                                 'Effect1|total',}
+        assert set(effect.model.constraints) == {'Effect1(invest)|total',
+                                                 'Effect1(operation)|total',
+                                                 'Effect1(operation)|total_per_timestep',
+                                                 'Effect1|total',}
+
+        assert_var_equal(model.variables['Effect1|total'], model.add_variables())
+        assert_var_equal(model.variables['Effect1(invest)|total'], model.add_variables())
+        assert_var_equal(model.variables['Effect1(operation)|total'], model.add_variables())
+        assert_var_equal(model.variables['Effect1(operation)|total_per_timestep'], model.add_variables(coords=(timesteps,)))
+
+        assert_conequal(model.constraints['Effect1|total'],
+                        model.variables['Effect1|total'] == model.variables['Effect1(operation)|total'] + model.variables['Effect1(invest)|total'])
+        assert_conequal(model.constraints['Effect1(invest)|total'], model.variables['Effect1(invest)|total'] == 0)
+        assert_conequal(model.constraints['Effect1(operation)|total'],
+                        model.variables['Effect1(operation)|total'] == model.variables['Effect1(operation)|total_per_timestep'].sum())
+        assert_conequal(model.constraints['Effect1(operation)|total_per_timestep'],
+                        model.variables['Effect1(operation)|total_per_timestep'] ==0)
+
+    def test_bounds(self, basic_flow_system_linopy):
+        flow_system = basic_flow_system_linopy
+        timesteps = flow_system.time_series_collection.timesteps
+        effect = fx.Effect('Effect1', '€', 'Testing Effect',
+                           minimum_operation=1.0,
+                           maximum_operation=1.1,
+                           minimum_invest=2.0,
+                           maximum_invest=2.1,
+                           minimum_total=3.0,
+                           maximum_total=3.1,
+                           minimum_operation_per_hour=4.0,
+                           maximum_operation_per_hour=4.1
+                           )
+
+        flow_system.add_elements(effect)
+        model = create_linopy_model(flow_system)
+
+        assert set(effect.model.variables) == {'Effect1(invest)|total',
+                                                 'Effect1(operation)|total',
+                                                 'Effect1(operation)|total_per_timestep',
+                                                 'Effect1|total',}
+        assert set(effect.model.constraints) == {'Effect1(invest)|total',
+                                                 'Effect1(operation)|total',
+                                                 'Effect1(operation)|total_per_timestep',
+                                                 'Effect1|total',}
+
+        assert_var_equal(model.variables['Effect1|total'], model.add_variables(lower=3.0, upper=3.1))
+        assert_var_equal(model.variables['Effect1(invest)|total'], model.add_variables(lower=2.0, upper=2.1))
+        assert_var_equal(model.variables['Effect1(operation)|total'], model.add_variables(lower=1.0, upper=1.1))
+        assert_var_equal(
+            model.variables['Effect1(operation)|total_per_timestep'], model.add_variables(
+                lower=4.0 * model.hours_per_step, upper=4.1* model.hours_per_step, coords=(timesteps,))
+        )
+
+        assert_conequal(model.constraints['Effect1|total'],
+                        model.variables['Effect1|total'] == model.variables['Effect1(operation)|total'] + model.variables['Effect1(invest)|total'])
+        assert_conequal(model.constraints['Effect1(invest)|total'], model.variables['Effect1(invest)|total'] == 0)
+        assert_conequal(model.constraints['Effect1(operation)|total'],
+                        model.variables['Effect1(operation)|total'] == model.variables['Effect1(operation)|total_per_timestep'].sum())
+        assert_conequal(model.constraints['Effect1(operation)|total_per_timestep'],
+                        model.variables['Effect1(operation)|total_per_timestep'] ==0)
+
+    def test_shares(self, basic_flow_system_linopy):
+        flow_system = basic_flow_system_linopy
+        timesteps = flow_system.time_series_collection.timesteps
+        effect1 = fx.Effect('Effect1', '€', 'Testing Effect',
+                           specific_share_to_other_effects_operation={
+                               'Effect2': 1.1,
+                               'Effect3': 1.2
+                           },
+                           specific_share_to_other_effects_invest={
+                               'Effect2': 2.1,
+                               'Effect3': 2.2
+                           }
+                           )
+        effect2 = fx.Effect('Effect2', '€', 'Testing Effect')
+        effect3 = fx.Effect('Effect3', '€', 'Testing Effect')
+        flow_system.add_elements(effect1, effect2, effect3)
+        model = create_linopy_model(flow_system)
+
+        assert set(effect2.model.variables) == {
+            'Effect2(invest)|total',
+            'Effect2(operation)|total',
+            'Effect2(operation)|total_per_timestep',
+            'Effect2|total',
+            'Effect1(invest)->Effect2(invest)',
+            'Effect1(operation)->Effect2(operation)',
+        }
+        assert set(effect2.model.constraints) == {
+            'Effect2(invest)|total',
+            'Effect2(operation)|total',
+            'Effect2(operation)|total_per_timestep',
+            'Effect2|total',
+            'Effect1(invest)->Effect2(invest)',
+            'Effect1(operation)->Effect2(operation)',
+        }
+
+        assert_conequal(
+            model.constraints['Effect2(invest)|total'],
+            model.variables['Effect2(invest)|total'] == model.variables['Effect1(invest)->Effect2(invest)'],
+        )
+
+        assert_conequal(
+            model.constraints['Effect2(operation)|total_per_timestep'],
+            model.variables['Effect2(operation)|total_per_timestep'] == model.variables['Effect1(operation)->Effect2(operation)'],
+        )
+
+        assert_conequal(
+            model.constraints['Effect1(operation)->Effect2(operation)'],
+            model.variables['Effect1(operation)->Effect2(operation)']
+            == model.variables['Effect1(operation)|total_per_timestep'] * 1.1
+        )
+
+        assert_conequal(
+            model.constraints['Effect1(invest)->Effect2(invest)'],
+            model.variables['Effect1(invest)->Effect2(invest)']
+            == model.variables['Effect1(invest)|total'] * 2.1,
+        )
+
+

--- a/tests/test_effect.py
+++ b/tests/test_effect.py
@@ -5,7 +5,7 @@ import xarray as xr
 
 import flixopt as fx
 
-from .conftest import basic_flow_system_linopy, create_linopy_model, assert_var_equal, assert_conequal
+from .conftest import assert_conequal, assert_var_equal, create_linopy_model
 
 
 class TestBusModel:
@@ -85,7 +85,6 @@ class TestBusModel:
 
     def test_shares(self, basic_flow_system_linopy):
         flow_system = basic_flow_system_linopy
-        timesteps = flow_system.time_series_collection.timesteps
         effect1 = fx.Effect('Effect1', '€', 'Testing Effect',
                            specific_share_to_other_effects_operation={
                                'Effect2': 1.1,

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -16,6 +16,7 @@ EXAMPLES_DIR = Path(__file__).parent.parent / 'examples'
     ),  # Sort by parent and script name
     ids=lambda path: str(path.relative_to(EXAMPLES_DIR)),  # Show relative file paths
 )
+@pytest.mark.slow
 def test_example_scripts(example_script):
     """
     Test all example scripts in the examples directory.

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -493,11 +493,6 @@ class TestFlowOnModel:
 
         assert_conequal(
             model.constraints['Sink(Wärme)|consecutive_on_hours_initial'],
-            model.variables['Sink(Wärme)|consecutive_on_hours'].isel(time=0) == model.variables['Sink(Wärme)|on'].isel(time=0) * model.hours_per_step.isel(time=0)
-        )
-
-        assert_conequal(
-            model.constraints['Sink(Wärme)|consecutive_on_hours_initial'],
             model.variables['Sink(Wärme)|consecutive_on_hours'].isel(time=0)
             == model.variables['Sink(Wärme)|on'].isel(time=0) * model.hours_per_step.isel(time=0),
         )
@@ -561,11 +556,6 @@ class TestFlowOnModel:
             >= model.variables['Sink(Wärme)|consecutive_off_hours'].isel(time=slice(None, -1))
             + model.hours_per_step.isel(time=slice(None, -1))
             + (model.variables['Sink(Wärme)|off'].isel(time=slice(1, None)) - 1) * mega
-        )
-
-        assert_conequal(
-            model.constraints['Sink(Wärme)|consecutive_off_hours_initial'],
-            model.variables['Sink(Wärme)|consecutive_off_hours'].isel(time=0) == model.variables['Sink(Wärme)|off'].isel(time=0) * model.hours_per_step.isel(time=0)
         )
 
         assert_conequal(

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -1,11 +1,11 @@
 import numpy as np
-import pytest
 import pandas as pd
+import pytest
 import xarray as xr
 
 import flixopt as fx
 
-from .conftest import basic_flow_system_linopy, create_linopy_model, assert_var_equal, assert_conequal
+from .conftest import assert_conequal, assert_var_equal, create_linopy_model
 
 
 class TestFlowModel:
@@ -583,7 +583,6 @@ class TestFlowOnModel:
     def test_switch_on_constraints(self, basic_flow_system_linopy):
         """Test flow with constraints on the number of startups."""
         flow_system = basic_flow_system_linopy
-        timesteps = flow_system.time_series_collection.timesteps
 
         flow = fx.Flow(
             'Wärme',
@@ -633,7 +632,6 @@ class TestFlowOnModel:
     def test_on_hours_limits(self, basic_flow_system_linopy):
         """Test flow with limits on total on hours."""
         flow_system = basic_flow_system_linopy
-        timesteps = flow_system.time_series_collection.timesteps
 
         flow = fx.Flow(
             'Wärme',

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -1,0 +1,896 @@
+import numpy as np
+import pytest
+import pandas as pd
+import xarray as xr
+
+import flixopt as fx
+
+from .conftest import basic_flow_system_linopy, create_linopy_model, assert_var_equal, assert_conequal
+
+
+class TestFlowModel:
+    """Test the FlowModel class."""
+
+    def test_flow_minimal(self, basic_flow_system_linopy):
+        """Test that flow model constraints are correctly generated."""
+        flow_system = basic_flow_system_linopy
+        timesteps = flow_system.time_series_collection.timesteps
+        flow = fx.Flow('Wärme', bus='Fernwärme', size=100)
+
+        flow_system.add_elements(fx.Sink('Sink', sink=flow))
+
+        model = create_linopy_model(flow_system)
+
+        assert_conequal(
+            model.constraints['Sink(Wärme)|total_flow_hours'],
+            flow.model.variables['Sink(Wärme)|total_flow_hours'] == (flow.model.variables['Sink(Wärme)|flow_rate'] * model.hours_per_step).sum()
+        )
+        assert_var_equal(flow.model.flow_rate,
+                            model.add_variables(lower=0, upper=100, coords=(timesteps,)))
+        assert_var_equal(flow.model.total_flow_hours, model.add_variables(lower=0))
+
+        assert set(flow.model.variables) == set(['Sink(Wärme)|total_flow_hours', 'Sink(Wärme)|flow_rate'])
+        assert set(flow.model.constraints) == set(['Sink(Wärme)|total_flow_hours'])
+
+    def test_flow(self, basic_flow_system_linopy):
+        flow_system = basic_flow_system_linopy
+        timesteps = flow_system.time_series_collection.timesteps
+        flow = fx.Flow(
+            'Wärme',
+            bus='Fernwärme',
+            size=100,
+            relative_minimum=np.linspace(0, 0.5, timesteps.size),
+            relative_maximum=np.linspace(0.5, 1, timesteps.size),
+            flow_hours_total_max=1000,
+            flow_hours_total_min=10,
+            load_factor_min=0.1,
+            load_factor_max=0.9,
+        )
+
+        flow_system.add_elements(fx.Sink('Sink', sink=flow))
+        model = create_linopy_model(flow_system)
+
+        # total_flow_hours
+        assert_conequal(
+            model.constraints['Sink(Wärme)|total_flow_hours'],
+            flow.model.variables['Sink(Wärme)|total_flow_hours']
+            == (flow.model.variables['Sink(Wärme)|flow_rate'] * model.hours_per_step).sum(),
+        )
+
+        assert_var_equal(
+            flow.model.total_flow_hours,
+            model.add_variables(lower=10, upper=1000)
+        )
+
+        assert_var_equal(
+            flow.model.flow_rate,
+            model.add_variables(lower=np.linspace(0, 0.5, timesteps.size) * 100,
+                                upper=np.linspace(0.5, 1, timesteps.size) * 100,
+                                coords=(timesteps,))
+        )
+
+        assert_conequal(
+            model.constraints['Sink(Wärme)|load_factor_min'],
+            flow.model.variables['Sink(Wärme)|total_flow_hours']
+            >= model.hours_per_step.sum('time') * 0.1 * 100,
+        )
+
+        assert_conequal(
+            model.constraints['Sink(Wärme)|load_factor_max'],
+            flow.model.variables['Sink(Wärme)|total_flow_hours']
+            <= model.hours_per_step.sum('time') * 0.9 * 100,
+        )
+
+        assert set(flow.model.variables) == set(['Sink(Wärme)|total_flow_hours', 'Sink(Wärme)|flow_rate'])
+        assert set(flow.model.constraints) == set(['Sink(Wärme)|total_flow_hours', 'Sink(Wärme)|load_factor_max', 'Sink(Wärme)|load_factor_min'])
+
+    def test_effects_per_flow_hour(self, basic_flow_system_linopy):
+        flow_system = basic_flow_system_linopy
+        timesteps = flow_system.time_series_collection.timesteps
+
+        costs_per_flow_hour = xr.DataArray(np.linspace(1,2,timesteps.size), coords=(timesteps,))
+        co2_per_flow_hour = xr.DataArray(np.linspace(4, 5, timesteps.size), coords=(timesteps,))
+
+        flow = fx.Flow(
+            'Wärme',
+            bus='Fernwärme',
+            effects_per_flow_hour={'Costs': costs_per_flow_hour, 'CO2': co2_per_flow_hour}
+        )
+        flow_system.add_elements(fx.Sink('Sink', sink=flow), fx.Effect('CO2', 't', ''))
+        model = create_linopy_model(flow_system)
+        costs, co2 = flow_system.effects['Costs'], flow_system.effects['CO2']
+
+        assert set(flow.model.variables) == {'Sink(Wärme)|total_flow_hours', 'Sink(Wärme)|flow_rate'}
+        assert set(flow.model.constraints) == {'Sink(Wärme)|total_flow_hours'}
+
+        assert 'Sink(Wärme)->Costs(operation)' in set(costs.model.constraints)
+        assert 'Sink(Wärme)->CO2(operation)' in set(co2.model.constraints)
+
+        assert_conequal(
+            model.constraints['Sink(Wärme)->Costs(operation)'],
+            model.variables['Sink(Wärme)->Costs(operation)'] == flow.model.variables['Sink(Wärme)|flow_rate'] * model.hours_per_step * costs_per_flow_hour)
+
+        assert_conequal(
+            model.constraints['Sink(Wärme)->CO2(operation)'],
+            model.variables['Sink(Wärme)->CO2(operation)'] == flow.model.variables['Sink(Wärme)|flow_rate'] * model.hours_per_step * co2_per_flow_hour)
+
+
+class TestFlowInvestModel:
+    """Test the FlowModel class."""
+
+    def test_flow_invest(self, basic_flow_system_linopy):
+        flow_system = basic_flow_system_linopy
+        timesteps = flow_system.time_series_collection.timesteps
+
+        flow = fx.Flow(
+            'Wärme',
+            bus='Fernwärme',
+            size=fx.InvestParameters(minimum_size=20, maximum_size=100, optional=False),
+            relative_minimum=np.linspace(0.1, 0.5, timesteps.size),
+            relative_maximum=np.linspace(0.5, 1, timesteps.size),
+        )
+
+        flow_system.add_elements(fx.Sink('Sink', sink=flow))
+        model = create_linopy_model(flow_system)
+
+        assert set(flow.model.variables) == set(
+            [
+                'Sink(Wärme)|total_flow_hours',
+                'Sink(Wärme)|flow_rate',
+                'Sink(Wärme)|size',
+            ]
+        )
+        assert set(flow.model.constraints) == set(
+            [
+                'Sink(Wärme)|total_flow_hours',
+                'Sink(Wärme)|lb_Sink(Wärme)|flow_rate',
+                'Sink(Wärme)|ub_Sink(Wärme)|flow_rate',
+            ]
+        )
+
+        # size
+        assert_var_equal(model['Sink(Wärme)|size'], model.add_variables(lower=20, upper=100))
+
+        # flow_rate
+        assert_var_equal(
+            flow.model.flow_rate,
+            model.add_variables(
+                lower=np.linspace(0.1, 0.5, timesteps.size) * 20,
+                upper=np.linspace(0.5, 1, timesteps.size) * 100,
+                coords=(timesteps,),
+            ),
+        )
+        assert_conequal(
+            model.constraints['Sink(Wärme)|lb_Sink(Wärme)|flow_rate'],
+            flow.model.variables['Sink(Wärme)|flow_rate']
+            >= flow.model.variables['Sink(Wärme)|size']
+            * xr.DataArray(np.linspace(0.1, 0.5, timesteps.size), coords=(timesteps,)),
+        )
+        assert_conequal(
+            model.constraints['Sink(Wärme)|ub_Sink(Wärme)|flow_rate'],
+            flow.model.variables['Sink(Wärme)|flow_rate']
+            <= flow.model.variables['Sink(Wärme)|size']
+            * xr.DataArray(np.linspace(0.5, 1, timesteps.size), coords=(timesteps,)),
+        )
+
+    def test_flow_invest_optional(self, basic_flow_system_linopy):
+        flow_system = basic_flow_system_linopy
+        timesteps = flow_system.time_series_collection.timesteps
+
+        flow = fx.Flow(
+            'Wärme',
+            bus='Fernwärme',
+            size=fx.InvestParameters(minimum_size=20, maximum_size=100, optional=True),
+            relative_minimum=np.linspace(0.1, 0.5, timesteps.size),
+            relative_maximum=np.linspace(0.5, 1, timesteps.size),
+        )
+
+        flow_system.add_elements(fx.Sink('Sink', sink=flow))
+        model = create_linopy_model(flow_system)
+
+        assert set(flow.model.variables) == set(
+            ['Sink(Wärme)|total_flow_hours', 'Sink(Wärme)|flow_rate', 'Sink(Wärme)|size', 'Sink(Wärme)|is_invested']
+        )
+        assert set(flow.model.constraints) == set(
+            [
+                'Sink(Wärme)|total_flow_hours',
+                'Sink(Wärme)|is_invested_ub',
+                'Sink(Wärme)|is_invested_lb',
+                'Sink(Wärme)|lb_Sink(Wärme)|flow_rate',
+                'Sink(Wärme)|ub_Sink(Wärme)|flow_rate',
+            ]
+        )
+
+        assert_var_equal(model['Sink(Wärme)|size'], model.add_variables(lower=0, upper=100))
+
+        assert_var_equal(model['Sink(Wärme)|is_invested'], model.add_variables(binary=True))
+
+        # flow_rate
+        assert_var_equal(
+            flow.model.flow_rate,
+            model.add_variables(
+                lower=0,  # Optional investment
+                upper=np.linspace(0.5, 1, timesteps.size) * 100,
+                coords=(timesteps,),
+            ),
+        )
+        assert_conequal(
+            model.constraints['Sink(Wärme)|lb_Sink(Wärme)|flow_rate'],
+            flow.model.variables['Sink(Wärme)|flow_rate']
+            >= flow.model.variables['Sink(Wärme)|size']
+            * xr.DataArray(np.linspace(0.1, 0.5, timesteps.size), coords=(timesteps,)),
+        )
+        assert_conequal(
+            model.constraints['Sink(Wärme)|ub_Sink(Wärme)|flow_rate'],
+            flow.model.variables['Sink(Wärme)|flow_rate']
+            <= flow.model.variables['Sink(Wärme)|size']
+            * xr.DataArray(np.linspace(0.5, 1, timesteps.size), coords=(timesteps,)),
+        )
+
+        # Is invested
+        assert_conequal(
+            model.constraints['Sink(Wärme)|is_invested_ub'],
+            flow.model.variables['Sink(Wärme)|size'] <= flow.model.variables['Sink(Wärme)|is_invested'] * 100,
+        )
+        assert_conequal(
+            model.constraints['Sink(Wärme)|is_invested_lb'],
+            flow.model.variables['Sink(Wärme)|size'] >= flow.model.variables['Sink(Wärme)|is_invested'] * 20,
+        )
+
+    def test_flow_invest_fixed_size(self, basic_flow_system_linopy):
+        """Test flow with fixed size investment."""
+        flow_system = basic_flow_system_linopy
+        timesteps = flow_system.time_series_collection.timesteps
+
+        flow = fx.Flow(
+            'Wärme',
+            bus='Fernwärme',
+            size=fx.InvestParameters(fixed_size=75, optional=False),
+            relative_minimum=0.2,
+            relative_maximum=0.9,
+        )
+
+        flow_system.add_elements(fx.Sink('Sink', sink=flow))
+        model = create_linopy_model(flow_system)
+
+        assert set(flow.model.variables) == {'Sink(Wärme)|total_flow_hours', 'Sink(Wärme)|flow_rate', 'Sink(Wärme)|size'}
+
+        # Check that size is fixed to 75
+        assert_var_equal(flow.model.variables['Sink(Wärme)|size'], model.add_variables(lower=75, upper=75))
+
+        # Check flow rate bounds
+        assert_var_equal(flow.model.flow_rate, model.add_variables(lower=0.2 * 75, upper=0.9 * 75, coords=(timesteps,)))
+
+    def test_flow_invest_with_effects(self, basic_flow_system_linopy):
+        """Test flow with investment effects."""
+        flow_system = basic_flow_system_linopy
+
+        # Create effects
+        co2 = fx.Effect(label='CO2', unit='ton', description='CO2 emissions')
+
+        flow = fx.Flow(
+            'Wärme',
+            bus='Fernwärme',
+            size=fx.InvestParameters(
+                minimum_size=20,
+                maximum_size=100,
+                optional=True,
+                fix_effects={'Costs': 1000, 'CO2': 5},  # Fixed investment effects
+                specific_effects={'Costs': 500, 'CO2': 0.1},  # Specific investment effects
+            ),
+        )
+
+        flow_system.add_elements( fx.Sink('Sink', sink=flow), co2)
+        model = create_linopy_model(flow_system)
+
+        # Check investment effects
+        assert 'Sink(Wärme)->Costs(invest)' in model.variables
+        assert 'Sink(Wärme)->CO2(invest)' in model.variables
+
+        # Check fix effects (applied only when is_invested=1)
+        assert_conequal(
+            model.constraints['Sink(Wärme)->Costs(invest)'],
+            model.variables['Sink(Wärme)->Costs(invest)']
+            == flow.model.variables['Sink(Wärme)|is_invested'] * 1000 + flow.model.variables['Sink(Wärme)|size'] * 500,
+        )
+
+        assert_conequal(
+            model.constraints['Sink(Wärme)->CO2(invest)'],
+            model.variables['Sink(Wärme)->CO2(invest)']
+            == flow.model.variables['Sink(Wärme)|is_invested'] * 5 + flow.model.variables['Sink(Wärme)|size'] * 0.1,
+        )
+
+    def test_flow_invest_divest_effects(self, basic_flow_system_linopy):
+        """Test flow with divestment effects."""
+        flow_system = basic_flow_system_linopy
+
+        flow = fx.Flow(
+            'Wärme',
+            bus='Fernwärme',
+            size=fx.InvestParameters(
+                minimum_size=20,
+                maximum_size=100,
+                optional=True,
+                divest_effects={'Costs': 500},  # Cost incurred when NOT investing
+            ),
+        )
+
+        flow_system.add_elements(fx.Sink('Sink', sink=flow))
+        model = create_linopy_model(flow_system)
+
+        # Check divestment effects
+        assert 'Sink(Wärme)->Costs(invest)' in model.constraints
+
+        assert_conequal(
+            model.constraints['Sink(Wärme)->Costs(invest)'],
+            model.variables['Sink(Wärme)->Costs(invest)'] + (model.variables['Sink(Wärme)|is_invested'] -1) * 500 == 0
+        )
+
+
+class TestFlowOnModel:
+    """Test the FlowModel class."""
+
+    def test_flow_on(self, basic_flow_system_linopy):
+        flow_system = basic_flow_system_linopy
+        timesteps = flow_system.time_series_collection.timesteps
+        flow = fx.Flow(
+            'Wärme',
+            bus='Fernwärme',
+            size=100,
+            relative_minimum=xr.DataArray(0.2, coords=(timesteps,)),
+            relative_maximum=xr.DataArray(0.8, coords=(timesteps,)),
+            on_off_parameters=fx.OnOffParameters(),
+        )
+        flow_system.add_elements(fx.Sink('Sink', sink=flow))
+        model = create_linopy_model(flow_system)
+
+        assert set(flow.model.variables) == set(
+            ['Sink(Wärme)|total_flow_hours', 'Sink(Wärme)|flow_rate', 'Sink(Wärme)|on', 'Sink(Wärme)|on_hours_total']
+        )
+
+        assert set(flow.model.constraints) == set(
+            [
+                'Sink(Wärme)|total_flow_hours',
+                'Sink(Wärme)|on_hours_total',
+                'Sink(Wärme)|on_con1',
+                'Sink(Wärme)|on_con2',
+            ]
+        )
+        # flow_rate
+        assert_var_equal(
+            flow.model.flow_rate,
+            model.add_variables(
+                lower=0,
+                upper=0.8 * 100,
+                coords=(timesteps,),
+            ),
+        )
+
+        # OnOff
+        assert_var_equal(
+            flow.model.on_off.on,
+            model.add_variables(binary=True, coords=(timesteps,)),
+        )
+        assert_var_equal(
+            model.variables['Sink(Wärme)|on_hours_total'],
+            model.add_variables(lower=0),
+        )
+        assert_conequal(
+            model.constraints['Sink(Wärme)|on_con1'],
+            flow.model.variables['Sink(Wärme)|on'] * 0.2 * 100 <= flow.model.variables['Sink(Wärme)|flow_rate'],
+        )
+        assert_conequal(
+            model.constraints['Sink(Wärme)|on_con2'],
+            flow.model.variables['Sink(Wärme)|on'] * 0.8 * 100 >= flow.model.variables['Sink(Wärme)|flow_rate'],
+        )
+
+        assert_conequal(
+            model.constraints['Sink(Wärme)|on_hours_total'],
+            flow.model.variables['Sink(Wärme)|on_hours_total']
+            == (flow.model.variables['Sink(Wärme)|on'] * model.hours_per_step).sum(),
+        )
+
+    def test_effects_per_running_hour(self, basic_flow_system_linopy):
+        flow_system = basic_flow_system_linopy
+        timesteps = flow_system.time_series_collection.timesteps
+
+        costs_per_running_hour = xr.DataArray(np.linspace(1, 2, timesteps.size), coords=(timesteps,))
+        co2_per_running_hour = xr.DataArray(np.linspace(4, 5, timesteps.size), coords=(timesteps,))
+
+        flow = fx.Flow(
+            'Wärme',
+            bus='Fernwärme',
+            on_off_parameters=fx.OnOffParameters(
+                effects_per_running_hour={'Costs': costs_per_running_hour, 'CO2': co2_per_running_hour}
+            ),
+        )
+        flow_system.add_elements(fx.Sink('Sink', sink=flow), fx.Effect('CO2', 't', ''))
+        model = create_linopy_model(flow_system)
+        costs, co2 = flow_system.effects['Costs'], flow_system.effects['CO2']
+
+        assert set(flow.model.variables) == {
+            'Sink(Wärme)|total_flow_hours',
+            'Sink(Wärme)|flow_rate',
+            'Sink(Wärme)|on',
+            'Sink(Wärme)|on_hours_total',
+        }
+        assert set(flow.model.constraints) == {
+            'Sink(Wärme)|total_flow_hours',
+            'Sink(Wärme)|on_con1',
+            'Sink(Wärme)|on_con2',
+            'Sink(Wärme)|on_hours_total',
+        }
+
+        assert 'Sink(Wärme)->Costs(operation)' in set(costs.model.constraints)
+        assert 'Sink(Wärme)->CO2(operation)' in set(co2.model.constraints)
+
+        assert_conequal(
+            model.constraints['Sink(Wärme)->Costs(operation)'],
+            model.variables['Sink(Wärme)->Costs(operation)']
+            == flow.model.variables['Sink(Wärme)|on'] * model.hours_per_step * costs_per_running_hour,
+        )
+
+        assert_conequal(
+            model.constraints['Sink(Wärme)->CO2(operation)'],
+            model.variables['Sink(Wärme)->CO2(operation)']
+            == flow.model.variables['Sink(Wärme)|on'] * model.hours_per_step * co2_per_running_hour,
+        )
+
+    def test_consecutive_on_hours(self, basic_flow_system_linopy):
+        """Test flow with minimum and maximum consecutive on hours."""
+        flow_system = basic_flow_system_linopy
+        timesteps = flow_system.time_series_collection.timesteps
+
+        flow = fx.Flow(
+            'Wärme',
+            bus='Fernwärme',
+            size=100,
+            on_off_parameters=fx.OnOffParameters(
+                consecutive_on_hours_min=2,  # Must run for at least 2 hours when turned on
+                consecutive_on_hours_max=8,  # Can't run more than 8 consecutive hours
+            ),
+        )
+
+        flow_system.add_elements( fx.Sink('Sink', sink=flow))
+        model = create_linopy_model(flow_system)
+
+        assert {'Sink(Wärme)|consecutive_on_hours', 'Sink(Wärme)|on'}.issubset(set(flow.model.variables))
+
+        assert {
+            'Sink(Wärme)|consecutive_on_hours_con1',
+         'Sink(Wärme)|consecutive_on_hours_con2a',
+         'Sink(Wärme)|consecutive_on_hours_con2b',
+         'Sink(Wärme)|consecutive_on_hours_initial',
+         'Sink(Wärme)|consecutive_on_hours_minimum_duration'
+        }.issubset(set(flow.model.constraints))
+
+        assert_var_equal(
+            model.variables['Sink(Wärme)|consecutive_on_hours'],
+            model.add_variables(lower=0, upper=8, coords=(timesteps,))
+        )
+
+        mega = model.hours_per_step.sum('time')
+
+        assert_conequal(
+            model.constraints['Sink(Wärme)|consecutive_on_hours_con1'],
+            model.variables['Sink(Wärme)|consecutive_on_hours'] <= model.variables['Sink(Wärme)|on'] * mega
+        )
+
+        assert_conequal(
+            model.constraints['Sink(Wärme)|consecutive_on_hours_con2a'],
+            model.variables['Sink(Wärme)|consecutive_on_hours'].isel(time=slice(1, None))
+            <= model.variables['Sink(Wärme)|consecutive_on_hours'].isel(time=slice(None, -1)) + model.hours_per_step.isel(time=slice(None, -1))
+        )
+
+        # eq: duration(t) >= duration(t - 1) + dt(t) + (On(t) - 1) * BIG
+        assert_conequal(
+            model.constraints['Sink(Wärme)|consecutive_on_hours_con2b'],
+            model.variables['Sink(Wärme)|consecutive_on_hours'].isel(time=slice(1, None))
+            >= model.variables['Sink(Wärme)|consecutive_on_hours'].isel(time=slice(None, -1))
+            + model.hours_per_step.isel(time=slice(None, -1))
+            + (model.variables['Sink(Wärme)|on'].isel(time=slice(1, None)) - 1) * mega
+        )
+
+        assert_conequal(
+            model.constraints['Sink(Wärme)|consecutive_on_hours_initial'],
+            model.variables['Sink(Wärme)|consecutive_on_hours'].isel(time=0) == model.variables['Sink(Wärme)|on'].isel(time=0) * model.hours_per_step.isel(time=0)
+        )
+
+        assert_conequal(
+            model.constraints['Sink(Wärme)|consecutive_on_hours_initial'],
+            model.variables['Sink(Wärme)|consecutive_on_hours'].isel(time=0)
+            == model.variables['Sink(Wärme)|on'].isel(time=0) * model.hours_per_step.isel(time=0),
+        )
+
+        assert_conequal(
+            model.constraints['Sink(Wärme)|consecutive_on_hours_minimum_duration'],
+            model.variables['Sink(Wärme)|consecutive_on_hours']
+            >= (model.variables['Sink(Wärme)|on'].isel(time=slice(None, -1)) - model.variables['Sink(Wärme)|on'].isel(time=slice(1, None))) * 2
+        )
+
+    def test_consecutive_off_hours(self, basic_flow_system_linopy):
+        """Test flow with minimum and maximum consecutive off hours."""
+        flow_system = basic_flow_system_linopy
+        timesteps = flow_system.time_series_collection.timesteps
+
+        flow = fx.Flow(
+            'Wärme',
+            bus='Fernwärme',
+            size=100,
+            on_off_parameters=fx.OnOffParameters(
+                consecutive_off_hours_min=4,  # Must stay off for at least 4 hours when shut down
+                consecutive_off_hours_max=12,  # Can't be off for more than 12 consecutive hours
+            ),
+        )
+
+        flow_system.add_elements( fx.Sink('Sink', sink=flow))
+        model = create_linopy_model(flow_system)
+
+        assert {'Sink(Wärme)|consecutive_off_hours', 'Sink(Wärme)|off'}.issubset(set(flow.model.variables))
+
+        assert {
+            'Sink(Wärme)|consecutive_off_hours_con1',
+         'Sink(Wärme)|consecutive_off_hours_con2a',
+         'Sink(Wärme)|consecutive_off_hours_con2b',
+         'Sink(Wärme)|consecutive_off_hours_initial',
+         'Sink(Wärme)|consecutive_off_hours_minimum_duration'
+        }.issubset(set(flow.model.constraints))
+
+        assert_var_equal(
+            model.variables['Sink(Wärme)|consecutive_off_hours'],
+            model.add_variables(lower=0, upper=12, coords=(timesteps,))
+        )
+
+        mega = model.hours_per_step.sum('time') + 1  # previously off for 1h
+
+        assert_conequal(
+            model.constraints['Sink(Wärme)|consecutive_off_hours_con1'],
+            model.variables['Sink(Wärme)|consecutive_off_hours'] <= model.variables['Sink(Wärme)|off'] * mega
+        )
+
+        assert_conequal(
+            model.constraints['Sink(Wärme)|consecutive_off_hours_con2a'],
+            model.variables['Sink(Wärme)|consecutive_off_hours'].isel(time=slice(1, None))
+            <= model.variables['Sink(Wärme)|consecutive_off_hours'].isel(time=slice(None, -1)) + model.hours_per_step.isel(time=slice(None, -1))
+        )
+
+        # eq: duration(t) >= duration(t - 1) + dt(t) + (On(t) - 1) * BIG
+        assert_conequal(
+            model.constraints['Sink(Wärme)|consecutive_off_hours_con2b'],
+            model.variables['Sink(Wärme)|consecutive_off_hours'].isel(time=slice(1, None))
+            >= model.variables['Sink(Wärme)|consecutive_off_hours'].isel(time=slice(None, -1))
+            + model.hours_per_step.isel(time=slice(None, -1))
+            + (model.variables['Sink(Wärme)|off'].isel(time=slice(1, None)) - 1) * mega
+        )
+
+        assert_conequal(
+            model.constraints['Sink(Wärme)|consecutive_off_hours_initial'],
+            model.variables['Sink(Wärme)|consecutive_off_hours'].isel(time=0) == model.variables['Sink(Wärme)|off'].isel(time=0) * model.hours_per_step.isel(time=0)
+        )
+
+        assert_conequal(
+            model.constraints['Sink(Wärme)|consecutive_off_hours_initial'],
+            model.variables['Sink(Wärme)|consecutive_off_hours'].isel(time=0)
+            == model.variables['Sink(Wärme)|off'].isel(time=0) * model.hours_per_step.isel(time=0),
+        )
+
+        assert_conequal(
+            model.constraints['Sink(Wärme)|consecutive_off_hours_minimum_duration'],
+            model.variables['Sink(Wärme)|consecutive_off_hours']
+            >= (model.variables['Sink(Wärme)|off'].isel(time=slice(None, -1)) - model.variables['Sink(Wärme)|off'].isel(time=slice(1, None))) * 4
+        )
+
+    def test_switch_on_constraints(self, basic_flow_system_linopy):
+        """Test flow with constraints on the number of startups."""
+        flow_system = basic_flow_system_linopy
+        timesteps = flow_system.time_series_collection.timesteps
+
+        flow = fx.Flow(
+            'Wärme',
+            bus='Fernwärme',
+            size=100,
+            on_off_parameters=fx.OnOffParameters(
+                switch_on_total_max=5,  # Maximum 5 startups
+                effects_per_switch_on={'Costs': 100},  # 100 EUR startup cost
+            ),
+        )
+
+        flow_system.add_elements(fx.Sink('Sink', sink=flow))
+        model = create_linopy_model(flow_system)
+
+        # Check that variables exist
+        assert {'Sink(Wärme)|switch_on', 'Sink(Wärme)|switch_off', 'Sink(Wärme)|switch_on_nr'}.issubset(
+            set(flow.model.variables)
+        )
+
+        # Check that constraints exist
+        assert {
+            'Sink(Wärme)|switch_con',
+            'Sink(Wärme)|initial_switch_con',
+            'Sink(Wärme)|switch_on_or_off',
+            'Sink(Wärme)|switch_on_nr',
+        }.issubset(set(flow.model.constraints))
+
+        # Check switch_on_nr variable bounds
+        assert_var_equal(flow.model.variables['Sink(Wärme)|switch_on_nr'], model.add_variables(lower=0, upper=5))
+
+        # Verify switch_on_nr constraint (limits number of startups)
+        assert_conequal(
+            model.constraints['Sink(Wärme)|switch_on_nr'],
+            flow.model.variables['Sink(Wärme)|switch_on_nr']
+            == flow.model.variables['Sink(Wärme)|switch_on'].sum('time'),
+        )
+
+        # Check that startup cost effect constraint exists
+        assert 'Sink(Wärme)->Costs(operation)' in model.constraints
+
+        # Verify the startup cost effect constraint
+        assert_conequal(
+            model.constraints['Sink(Wärme)->Costs(operation)'],
+            model.variables['Sink(Wärme)->Costs(operation)'] == flow.model.variables['Sink(Wärme)|switch_on'] * 100,
+        )
+
+    def test_on_hours_limits(self, basic_flow_system_linopy):
+        """Test flow with limits on total on hours."""
+        flow_system = basic_flow_system_linopy
+        timesteps = flow_system.time_series_collection.timesteps
+
+        flow = fx.Flow(
+            'Wärme',
+            bus='Fernwärme',
+            size=100,
+            on_off_parameters=fx.OnOffParameters(
+                on_hours_total_min=20,  # Minimum 20 hours of operation
+                on_hours_total_max=100,  # Maximum 100 hours of operation
+            ),
+        )
+
+        flow_system.add_elements(fx.Sink('Sink', sink=flow))
+        model = create_linopy_model(flow_system)
+
+        # Check that variables exist
+        assert {'Sink(Wärme)|on', 'Sink(Wärme)|on_hours_total'}.issubset(set(flow.model.variables))
+
+        # Check that constraints exist
+        assert 'Sink(Wärme)|on_hours_total' in model.constraints
+
+        # Check on_hours_total variable bounds
+        assert_var_equal(flow.model.variables['Sink(Wärme)|on_hours_total'], model.add_variables(lower=20, upper=100))
+
+        # Check on_hours_total constraint
+        assert_conequal(
+            model.constraints['Sink(Wärme)|on_hours_total'],
+            flow.model.variables['Sink(Wärme)|on_hours_total']
+            == (flow.model.variables['Sink(Wärme)|on'] * model.hours_per_step).sum(),
+        )
+
+
+class TestFlowOnInvestModel:
+    """Test the FlowModel class."""
+
+    def test_flow_on_invest_optional(self, basic_flow_system_linopy):
+        flow_system = basic_flow_system_linopy
+        timesteps = flow_system.time_series_collection.timesteps
+        flow = fx.Flow(
+            'Wärme',
+            bus='Fernwärme',
+            size=fx.InvestParameters(minimum_size=20, maximum_size=200, optional=True),
+            relative_minimum=xr.DataArray(0.2, coords=(timesteps,)),
+            relative_maximum=xr.DataArray(0.8, coords=(timesteps,)),
+            on_off_parameters=fx.OnOffParameters(),
+        )
+        flow_system.add_elements(fx.Sink('Sink', sink=flow))
+        model = create_linopy_model(flow_system)
+
+        assert set(flow.model.variables) == set(
+            [
+                'Sink(Wärme)|total_flow_hours',
+                'Sink(Wärme)|flow_rate',
+                'Sink(Wärme)|is_invested',
+                'Sink(Wärme)|size',
+                'Sink(Wärme)|on',
+                'Sink(Wärme)|on_hours_total',
+            ]
+        )
+
+        assert set(flow.model.constraints) == set(
+            [
+                'Sink(Wärme)|total_flow_hours',
+                'Sink(Wärme)|on_hours_total',
+                'Sink(Wärme)|on_con1',
+                'Sink(Wärme)|on_con2',
+                'Sink(Wärme)|is_invested_lb',
+                'Sink(Wärme)|is_invested_ub',
+                'Sink(Wärme)|lb_Sink(Wärme)|flow_rate',
+                'Sink(Wärme)|ub_Sink(Wärme)|flow_rate',
+            ]
+        )
+
+        # flow_rate
+        assert_var_equal(
+            flow.model.flow_rate,
+            model.add_variables(
+                lower=0,
+                upper=0.8 * 200,
+                coords=(timesteps,),
+            ),
+        )
+
+        # OnOff
+        assert_var_equal(
+            flow.model.on_off.on,
+            model.add_variables(binary=True, coords=(timesteps,)),
+        )
+        assert_var_equal(
+            model.variables['Sink(Wärme)|on_hours_total'],
+            model.add_variables(lower=0),
+        )
+        assert_conequal(
+            model.constraints['Sink(Wärme)|on_con1'],
+            flow.model.variables['Sink(Wärme)|on'] * 0.2 * 20 <= flow.model.variables['Sink(Wärme)|flow_rate'],
+        )
+        assert_conequal(
+            model.constraints['Sink(Wärme)|on_con2'],
+            flow.model.variables['Sink(Wärme)|on'] * 0.8 * 200 >= flow.model.variables['Sink(Wärme)|flow_rate'],
+        )
+        assert_conequal(
+            model.constraints['Sink(Wärme)|on_hours_total'],
+            flow.model.variables['Sink(Wärme)|on_hours_total']
+            == (flow.model.variables['Sink(Wärme)|on'] * model.hours_per_step).sum(),
+        )
+
+        # Investment
+        assert_var_equal(model['Sink(Wärme)|size'], model.add_variables(lower=0, upper=200))
+
+        mega = 0.2 * 200  # Relative minimum * maximum size
+        assert_conequal(
+            model.constraints['Sink(Wärme)|lb_Sink(Wärme)|flow_rate'],
+            flow.model.variables['Sink(Wärme)|flow_rate']
+            >= flow.model.variables['Sink(Wärme)|on'] * mega + flow.model.variables['Sink(Wärme)|size'] * 0.2 - mega,
+        )
+        assert_conequal(
+            model.constraints['Sink(Wärme)|ub_Sink(Wärme)|flow_rate'],
+            flow.model.variables['Sink(Wärme)|flow_rate'] <= flow.model.variables['Sink(Wärme)|size'] * 0.8,
+        )
+
+    def test_flow_on_invest_non_optional(self, basic_flow_system_linopy):
+        flow_system = basic_flow_system_linopy
+        timesteps = flow_system.time_series_collection.timesteps
+        flow = fx.Flow(
+            'Wärme',
+            bus='Fernwärme',
+            size=fx.InvestParameters(minimum_size=20, maximum_size=200, optional=False),
+            relative_minimum=xr.DataArray(0.2, coords=(timesteps,)),
+            relative_maximum=xr.DataArray(0.8, coords=(timesteps,)),
+            on_off_parameters=fx.OnOffParameters(),
+        )
+        flow_system.add_elements(fx.Sink('Sink', sink=flow))
+        model = create_linopy_model(flow_system)
+
+        assert set(flow.model.variables) == set(
+            [
+                'Sink(Wärme)|total_flow_hours',
+                'Sink(Wärme)|flow_rate',
+                'Sink(Wärme)|size',
+                'Sink(Wärme)|on',
+                'Sink(Wärme)|on_hours_total',
+            ]
+        )
+
+        assert set(flow.model.constraints) == set(
+            [
+                'Sink(Wärme)|total_flow_hours',
+                'Sink(Wärme)|on_hours_total',
+                'Sink(Wärme)|on_con1',
+                'Sink(Wärme)|on_con2',
+                'Sink(Wärme)|lb_Sink(Wärme)|flow_rate',
+                'Sink(Wärme)|ub_Sink(Wärme)|flow_rate',
+            ]
+        )
+
+        # flow_rate
+        assert_var_equal(
+            flow.model.flow_rate,
+            model.add_variables(
+                lower=0,
+                upper=0.8 * 200,
+                coords=(timesteps,),
+            ),
+        )
+
+        # OnOff
+        assert_var_equal(
+            flow.model.on_off.on,
+            model.add_variables(binary=True, coords=(timesteps,)),
+        )
+        assert_var_equal(
+            model.variables['Sink(Wärme)|on_hours_total'],
+            model.add_variables(lower=0),
+        )
+        assert_conequal(
+            model.constraints['Sink(Wärme)|on_con1'],
+            flow.model.variables['Sink(Wärme)|on'] * 0.2 * 20 <= flow.model.variables['Sink(Wärme)|flow_rate'],
+        )
+        assert_conequal(
+            model.constraints['Sink(Wärme)|on_con2'],
+            flow.model.variables['Sink(Wärme)|on'] * 0.8 * 200 >= flow.model.variables['Sink(Wärme)|flow_rate'],
+        )
+        assert_conequal(
+            model.constraints['Sink(Wärme)|on_hours_total'],
+            flow.model.variables['Sink(Wärme)|on_hours_total']
+            == (flow.model.variables['Sink(Wärme)|on'] * model.hours_per_step).sum(),
+        )
+
+        # Investment
+        assert_var_equal(model['Sink(Wärme)|size'], model.add_variables(lower=20, upper=200))
+
+        mega = 0.2 * 200  # Relative minimum * maximum size
+        assert_conequal(
+            model.constraints['Sink(Wärme)|lb_Sink(Wärme)|flow_rate'],
+            flow.model.variables['Sink(Wärme)|flow_rate']
+            >= flow.model.variables['Sink(Wärme)|on'] * mega + flow.model.variables['Sink(Wärme)|size'] * 0.2 - mega,
+        )
+        assert_conequal(
+            model.constraints['Sink(Wärme)|ub_Sink(Wärme)|flow_rate'],
+            flow.model.variables['Sink(Wärme)|flow_rate'] <= flow.model.variables['Sink(Wärme)|size'] * 0.8,
+        )
+
+
+class TestFlowWithFixedProfile:
+    """Test Flow with fixed relative profile."""
+
+    def test_fixed_relative_profile(self, basic_flow_system_linopy):
+        """Test flow with a fixed relative profile."""
+        flow_system = basic_flow_system_linopy
+        timesteps = flow_system.time_series_collection.timesteps
+
+        # Create a time-varying profile (e.g., for a load or renewable generation)
+        profile = np.sin(np.linspace(0, 2 * np.pi, len(timesteps))) * 0.5 + 0.5  # Values between 0 and 1
+
+        flow = fx.Flow(
+            'Wärme', bus='Fernwärme', size=100, fixed_relative_profile=xr.DataArray(profile, coords=(timesteps,))
+        )
+
+        flow_system.add_elements(fx.Sink('Sink', sink=flow))
+        model = create_linopy_model(flow_system)
+
+        assert_var_equal(flow.model.variables['Sink(Wärme)|flow_rate'],
+                         model.add_variables(lower=profile * 100,
+                                             upper=profile * 100,
+                                             coords=(timesteps,))
+                         )
+
+
+    def test_fixed_profile_with_investment(self, basic_flow_system_linopy):
+        """Test flow with fixed profile and investment."""
+        flow_system = basic_flow_system_linopy
+        timesteps = flow_system.time_series_collection.timesteps
+
+        # Create a fixed profile
+        profile = np.sin(np.linspace(0, 2 * np.pi, len(timesteps))) * 0.5 + 0.5
+
+        flow = fx.Flow(
+            'Wärme',
+            bus='Fernwärme',
+            size=fx.InvestParameters(minimum_size=50, maximum_size=200, optional=True),
+            fixed_relative_profile=xr.DataArray(profile, coords=(timesteps,)),
+        )
+
+        flow_system.add_elements( fx.Sink('Sink', sink=flow))
+        model = create_linopy_model(flow_system)
+
+        assert_var_equal(
+            flow.model.variables['Sink(Wärme)|flow_rate'],
+            model.add_variables(lower=0, upper=profile * 200, coords=(timesteps,)),
+        )
+
+        # The constraint should link flow_rate to size * profile
+        assert_conequal(
+            model.constraints['Sink(Wärme)|fix_Sink(Wärme)|flow_rate'],
+            flow.model.variables['Sink(Wärme)|flow_rate']
+            == flow.model.variables['Sink(Wärme)|size'] * xr.DataArray(profile, coords=(timesteps,)),
+        )
+
+
+if __name__ == '__main__':
+    pytest.main()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -354,7 +354,7 @@ class TestComplex:
             'Speicher investCosts_segmented_costs doesnt match expected value',
         )
 
-
+@pytest.mark.slow
 class TestModelingTypes:
     @pytest.fixture(params=['full', 'segmented', 'aggregated'])
     def modeling_calculation(self, request, flow_system_long, highs_solver):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -22,7 +22,7 @@ def flow_system(request):
     else:
         return fs[0]
 
-
+@pytest.mark.slow
 def test_flow_system_file_io(flow_system, highs_solver):
     calculation_0 = fx.FullCalculation('IO', flow_system=flow_system)
     calculation_0.do_modeling()

--- a/tests/test_on_hours_computation.py
+++ b/tests/test_on_hours_computation.py
@@ -42,3 +42,64 @@ class TestComputeConsecutiveDuration:
         """Test error conditions."""
         with pytest.raises(TypeError):
             OnOffModel.compute_consecutive_duration(binary_values, hours_per_timestep)
+
+
+class TestComputePreviousOnStates:
+    """Tests for the compute_previous_on_states static method."""
+
+    @pytest.mark.parametrize(
+        'previous_values, expected',
+        [
+            # Case 1: Empty list
+            ([], np.array([0])),
+
+            # Case 2: All None values
+            ([None, None], np.array([0])),
+
+            # Case 3: Single value arrays
+            ([np.array([0])], np.array([0])),
+            ([np.array([1])], np.array([1])),
+            ([np.array([0.001])], np.array([1])),  # Using default epsilon
+            ([np.array([1e-4])], np.array([1])),
+            ([np.array([1e-8])], np.array([0])),
+
+            # Case 4: Multiple 1D arrays
+            ([np.array([0, 5, 0]), np.array([0, 0, 1])], np.array([0, 1, 1])),
+            ([np.array([0.1, 0, 0.3]), None, np.array([0, 0, 0])], np.array([1, 0, 1])),
+            ([np.array([0, 0, 0]), np.array([0, 1, 0])], np.array([0, 1, 0])),
+            ([np.array([0.1, 0, 0]), np.array([0, 0, 0.2])], np.array([1, 0, 1])),
+
+            # Case 6: Mix of None, 1D and 2D arrays
+            ([None, np.array([0, 0, 0]), np.array([0, 1, 0]), np.array([0, 0, 0])], np.array([0, 1, 0])),
+            ([np.array([0, 0, 0]), None, np.array([0, 0, 0]), np.array([0, 0, 0])], np.array([0, 0, 0])),
+        ],
+    )
+    def test_compute_previous_on_states(self, previous_values, expected):
+        """Test compute_previous_on_states with various inputs."""
+        result = OnOffModel.compute_previous_on_states(previous_values)
+        np.testing.assert_array_equal(result, expected)
+
+    @pytest.mark.parametrize("previous_values, epsilon, expected", [
+        # Testing with different epsilon values
+        ([np.array([1e-6, 1e-4, 1e-2])], 1e-3, np.array([0, 0, 1])),
+        ([np.array([1e-6, 1e-4, 1e-2])], 1e-5, np.array([0, 1, 1])),
+        ([np.array([1e-6, 1e-4, 1e-2])], 1e-1, np.array([0, 0, 0])),
+
+        # Mixed case with custom epsilon
+        ([np.array([0.05, 0.005, 0.0005])], 0.01, np.array([1, 0, 0])),
+    ])
+    def test_compute_previous_on_states_with_epsilon(self, previous_values, epsilon, expected):
+        """Test compute_previous_on_states with custom epsilon values."""
+        result = OnOffModel.compute_previous_on_states(previous_values, epsilon)
+        np.testing.assert_array_equal(result, expected)
+
+    @pytest.mark.parametrize("previous_values, expected_shape", [
+        # Check that output shapes match expected dimensions
+        ([np.array([0, 1, 0, 1])], (4,)),
+        ([np.array([0, 1]), np.array([1, 0]), np.array([0, 0])], (2,)),
+        ([np.array([0, 1]), np.array([1, 0])], (2,)),
+    ])
+    def test_output_shapes(self, previous_values, expected_shape):
+        """Test that output array has the correct shape."""
+        result = OnOffModel.compute_previous_on_states(previous_values)
+        assert result.shape == expected_shape

--- a/tests/test_on_hours_computation.py
+++ b/tests/test_on_hours_computation.py
@@ -1,0 +1,44 @@
+import numpy as np
+import pytest
+
+from flixopt.features import OnOffModel
+
+
+class TestComputeConsecutiveDuration:
+    """Tests for the compute_consecutive_duration static method."""
+
+    @pytest.mark.parametrize("binary_values, hours_per_timestep, expected", [
+        # Case 1: Both scalar inputs
+        (1, 5, 5),
+        (0, 3, 0),
+
+        # Case 2: Scalar binary, array hours
+        (1, np.array([1, 2, 3]), 3),
+        (0, np.array([2, 4, 6]), 0),
+
+        # Case 3: Array binary, scalar hours
+        (np.array([0, 0, 1, 1, 1, 0]), 2, 0),
+        (np.array([0, 1, 1, 0, 1, 1]), 1, 2),
+        (np.array([1, 1, 1]), 2, 6),
+
+        # Case 4: Both array inputs
+        (np.array([0, 1, 1, 0, 1, 1]), np.array([1, 2, 3, 4, 5, 6]), 11),  # 5+6
+        (np.array([1, 0, 0, 1, 1, 1]), np.array([2, 2, 2, 3, 4, 5]), 12),  # 3+4+5
+
+        # Case 5: Edge cases
+        (np.array([1]), np.array([4]), 4),
+        (np.array([0]), np.array([3]), 0),
+    ])
+    def test_compute_duration(self, binary_values, hours_per_timestep, expected):
+        """Test compute_consecutive_duration with various inputs."""
+        result = OnOffModel.compute_consecutive_duration(binary_values, hours_per_timestep)
+        assert np.isclose(result, expected)
+
+    @pytest.mark.parametrize("binary_values, hours_per_timestep", [
+        # Case: Incompatible array lengths
+        (np.array([1, 1, 1, 1, 1]), np.array([1, 2])),
+    ])
+    def test_compute_duration_raises_error(self, binary_values, hours_per_timestep):
+        """Test error conditions."""
+        with pytest.raises(TypeError):
+            OnOffModel.compute_consecutive_duration(binary_values, hours_per_timestep)

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -14,6 +14,7 @@ import pytest
 
 from flixopt import plotting
 
+
 @pytest.mark.slow
 class TestPlots(unittest.TestCase):
     def setUp(self):

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -14,7 +14,7 @@ import pytest
 
 from flixopt import plotting
 
-
+@pytest.mark.slow
 class TestPlots(unittest.TestCase):
     def setUp(self):
         np.random.seed(72)

--- a/tests/test_results_plots.py
+++ b/tests/test_results_plots.py
@@ -40,7 +40,7 @@ def plotting_engine(request):
 def color_spec(request):
     return request.param
 
-
+@pytest.mark.slow
 def test_results_plots(flow_system, plotting_engine, show, save, color_spec):
     calculation = create_calculation_and_solve(flow_system, fx.solvers.HighsSolver(0.01, 30), 'test_results_plots')
     results = calculation.results
@@ -67,7 +67,7 @@ def test_results_plots(flow_system, plotting_engine, show, save, color_spec):
 
     plt.close('all')
 
-
+@pytest.mark.slow
 def test_color_handling_edge_cases(flow_system, plotting_engine, show, save):
     """Test edge cases for color handling"""
     calculation = create_calculation_and_solve(flow_system, fx.solvers.HighsSolver(0.01, 30), 'test_color_edge_cases')

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -555,7 +555,7 @@ class TestTimeSeriesCollection:
     def test_class_method_with_uniform_timesteps(self):
         """Test the with_uniform_timesteps class method."""
         collection = TimeSeriesCollection.with_uniform_timesteps(
-            start_time=pd.Timestamp('2023-01-01'), periods=24, freq='H', hours_per_step=1
+            start_time=pd.Timestamp('2023-01-01'), periods=24, freq='h', hours_per_step=1
         )
 
         assert len(collection.timesteps) == 24


### PR DESCRIPTION
# Testing created Variables and constraints
Add new kinds of tests to flixopt, to directly check for modeled constraints and bound, instead of solving a model and checking for results.
Writing these test lead to some bugfixes (also mentioned here #232)

## Bugfixes
- Reorganized the computation of Bounds in FlowModel, including Bugfixes
- Fixes a Bug that prevented divest effects from working.
- added lower bounds of 0 to two unbounded vars

## Testing FAST
run
```bash
pytest -m "not slow"
```
This reduces testing time from **> 7 min** to **<30sec**

To exclude expensive/slow test (examples, plots, big models)


closes #232 