### PR TITLE
V3.0.0/invest

### DIFF
--- a/flixopt/__init__.py
+++ b/flixopt/__init__.py
@@ -16,6 +16,7 @@ from .commons import (
     FlowSystem,
     FullCalculation,
     InvestParameters,
+    InvestTimingParameters,
     LinearConverter,
     OnOffParameters,
     Piece,

--- a/flixopt/calculation.py
+++ b/flixopt/calculation.py
@@ -28,7 +28,7 @@ from .components import Storage
 from .config import CONFIG
 from .core import DataConverter, Scalar, TimeSeriesData, drop_constant_arrays
 from .elements import Component
-from .features import InvestmentModel
+from .features import InvestmentModel, InvestmentTimingModel
 from .flow_system import FlowSystem
 from .results import CalculationResults, SegmentedCalculationResults
 from .solvers import _Solver
@@ -113,13 +113,15 @@ class Calculation:
                     model.label_of_element: model.size.solution
                     for component in self.flow_system.components.values()
                     for model in component.submodel.all_submodels
-                    if isinstance(model, InvestmentModel) and model.size.solution.max() >= CONFIG.modeling.EPSILON
+                    if isinstance(model, (InvestmentModel, InvestmentTimingModel))
+                    and model.size.solution.max() >= CONFIG.modeling.EPSILON
                 },
                 'Not invested': {
                     model.label_of_element: model.size.solution
                     for component in self.flow_system.components.values()
                     for model in component.submodel.all_submodels
-                    if isinstance(model, InvestmentModel) and model.size.solution.max() < CONFIG.modeling.EPSILON
+                    if isinstance(model, (InvestmentModel, InvestmentTimingModel))
+                    and model.size.solution.max() < CONFIG.modeling.EPSILON
                 },
             },
             'Buses with excess': [

--- a/flixopt/commons.py
+++ b/flixopt/commons.py
@@ -18,7 +18,15 @@ from .core import TimeSeriesData
 from .effects import Effect
 from .elements import Bus, Flow
 from .flow_system import FlowSystem
-from .interface import InvestParameters, OnOffParameters, Piece, Piecewise, PiecewiseConversion, PiecewiseEffects
+from .interface import (
+    InvestParameters,
+    InvestTimingParameters,
+    OnOffParameters,
+    Piece,
+    Piecewise,
+    PiecewiseConversion,
+    PiecewiseEffects,
+)
 
 __all__ = [
     'TimeSeriesData',
@@ -48,4 +56,5 @@ __all__ = [
     'results',
     'linear_converters',
     'solvers',
+    'InvestTimingParameters',
 ]

--- a/flixopt/components.py
+++ b/flixopt/components.py
@@ -94,7 +94,7 @@ class LinearConverter(Component):
                         f'(in {self.label_full}) and variable size is uncommon. Please check if this is intended!'
                     )
 
-    def transform_data(self, flow_system: 'FlowSystem'):
+    def transform_data(self, flow_system: 'FlowSystem', name_prefix: str = '') -> None:
         super().transform_data(flow_system)
         if self.conversion_factors:
             self.conversion_factors = self._transform_conversion_factors(flow_system)
@@ -207,7 +207,7 @@ class Storage(Component):
         self.submodel = StorageModel(model, self)
         return self.submodel
 
-    def transform_data(self, flow_system: 'FlowSystem') -> None:
+    def transform_data(self, flow_system: 'FlowSystem', name_prefix: str = '') -> None:
         super().transform_data(flow_system)
         self.relative_minimum_charge_state = flow_system.fit_to_model_coords(
             f'{self.label_full}|relative_minimum_charge_state',
@@ -393,7 +393,7 @@ class Transmission(Component):
         self.submodel = TransmissionModel(model, self)
         return self.submodel
 
-    def transform_data(self, flow_system: 'FlowSystem') -> None:
+    def transform_data(self, flow_system: 'FlowSystem', name_prefix: str = '') -> None:
         super().transform_data(flow_system)
         self.relative_losses = flow_system.fit_to_model_coords(
             f'{self.label_full}|relative_losses', self.relative_losses

--- a/flixopt/effects.py
+++ b/flixopt/effects.py
@@ -13,7 +13,7 @@ import linopy
 import numpy as np
 import xarray as xr
 
-from .core import Scalar, TemporalData, TemporalDataUser
+from .core import NonTemporalDataUser, Scalar, TemporalData, TemporalDataUser
 from .features import ShareAllocationModel
 from .structure import Element, ElementModel, FlowSystemModel, Interface, Submodel, register_class_for_io
 
@@ -192,7 +192,7 @@ class EffectModel(ElementModel):
 TemporalEffectsUser = Union[TemporalDataUser, Dict[str, TemporalDataUser]]  # User-specified Shares to Effects
 """ This datatype is used to define a temporal share to an effect by a certain attribute. """
 
-NonTemporalEffectsUser = Union[Scalar, Dict[str, Scalar]]  # User-specified Shares to Effects
+NonTemporalEffectsUser = Union[NonTemporalDataUser, Dict[str, NonTemporalDataUser]]  # User-specified Shares to Effects
 """ This datatype is used to define a scalar share to an effect by a certain attribute. """
 
 TemporalEffects = Dict[str, TemporalData]  # User-specified Shares to Effects

--- a/flixopt/structure.py
+++ b/flixopt/structure.py
@@ -178,7 +178,11 @@ class FlowSystemModel(linopy.Model, SubmodelsMixin):
     def weights(self) -> Union[int, xr.DataArray]:
         """Returns the scenario weights of the FlowSystem. If None, return weights that are normalized to 1 (one)"""
         if self.flow_system.weights is None:
-            weights = self.flow_system.fit_to_model_coords('weights', 1, dims=['year', 'scenario'])
+            weights = self.flow_system.fit_to_model_coords(
+                'weights',
+                1 if self.flow_system.years is None else self.flow_system.years_per_year,
+                dims=['year', 'scenario'],
+            )
 
             return weights / weights.sum()
 
@@ -225,11 +229,12 @@ class Interface:
         transform_data(flow_system): Transform data to match FlowSystem dimensions
     """
 
-    def transform_data(self, flow_system: 'FlowSystem'):
+    def transform_data(self, flow_system: 'FlowSystem', name_prefix: str = '') -> None:
         """Transform the data of the interface to match the FlowSystem's dimensions.
 
         Args:
             flow_system: The FlowSystem containing timing and dimensional information
+            name_prefix: The prefix to use for the names of the variables. Defaults to '', which results in no prefix.
 
         Raises:
             NotImplementedError: Must be implemented by subclasses

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,231 @@
+from typing import Union
+
+import linopy
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+import flixopt as fx
+
+from .conftest import (
+    Buses,
+    Effects,
+    LoadProfiles,
+    Sinks,
+    Sources,
+    assert_conequal,
+    assert_sets_equal,
+    assert_var_equal,
+    create_linopy_model,
+)
+
+
+def calculate_annual_payment(total_cost: float, remaining_years: int, discount_rate: float) -> float:
+    """Calculate annualized payment for given remaining years.
+
+    Args:
+        total_cost: Total cost to be annualized.
+        remaining_years: Number of remaining years.
+        discount_rate: Discount rate for annualization.
+
+    Returns:
+        Annual payment amount.
+    """
+    if remaining_years == 1:
+        return total_cost
+
+    return (
+        total_cost
+        * (discount_rate * (1 + discount_rate) ** remaining_years)
+        / ((1 + discount_rate) ** remaining_years - 1)
+    )
+
+
+def create_annualized_effects(
+    year_of_investments: Union[range, list, pd.Index],
+    all_years: Union[range, list, pd.Index],
+    total_cost: float,
+    discount_rate: float,
+    horizon_end: int,
+    extra_dim: str = 'year_of_investment',
+) -> xr.DataArray:
+    """Create a 2D effects array for annualized costs.
+
+    Creates an array where investing in year Y results in annualized costs
+    applied to years Y through horizon_end.
+
+    Args:
+        year_of_investments: Years when investment decisions can be made.
+        all_years: All years in the model (for the 'year' dimension).
+        total_cost: Total upfront cost to be annualized.
+        discount_rate: Discount rate for annualization calculation.
+        horizon_end: Last year when effects apply.
+        extra_dim: Name for the investment year dimension.
+
+    Returns:
+        xr.DataArray with dimensions [extra_dim, 'year'] containing annualized costs.
+    """
+
+    # Convert to lists for easier iteration
+    year_of_investments_list = list(year_of_investments)
+    all_years_list = list(all_years)
+
+    # Initialize cost matrix
+    cost_matrix = np.zeros((len(year_of_investments_list), len(all_years_list)))
+
+    # Fill matrix with annualized costs
+    for i, year_of_investment in enumerate(year_of_investments_list):
+        remaining_years = horizon_end - year_of_investment + 1
+        if remaining_years > 0:
+            annual_cost = calculate_annual_payment(total_cost, remaining_years, discount_rate)
+
+            # Apply cost to years from year_of_investment through horizon_end
+            for j, cost_year in enumerate(all_years_list):
+                if year_of_investment <= cost_year <= horizon_end:
+                    cost_matrix[i, j] = annual_cost
+
+    return xr.DataArray(
+        cost_matrix, coords={extra_dim: year_of_investments_list, 'year': all_years_list}, dims=[extra_dim, 'year']
+    )
+
+
+@pytest.fixture
+def flow_system() -> fx.FlowSystem:
+    """Create basic elements for component testing with coordinate parametrization."""
+    years = pd.Index([2020, 2021, 2022, 2023, 2024, 2026, 2028, 2030], name='year')
+    timesteps = pd.date_range('2020-01-01', periods=24, freq='h', name='time')
+    flow_system = fx.FlowSystem(timesteps=timesteps, years=years)
+
+    thermal_load = LoadProfiles.random_thermal(len(timesteps))
+    p_el = LoadProfiles.random_electrical(len(timesteps))
+
+    costs = Effects.costs()
+    heat_load = Sinks.heat_load(thermal_load)
+    gas_source = Sources.gas_with_costs()
+    electricity_sink = Sinks.electricity_feed_in(p_el)
+
+    flow_system.add_elements(*Buses.defaults())
+    flow_system.buses['Fernwärme'].excess_penalty_per_flow_hour = 0
+    flow_system.add_elements(costs, heat_load, gas_source, electricity_sink)
+
+    return flow_system
+
+
+class TestYearAwareInvestParameters:
+    """Test the YearAwareInvestParameters interface."""
+
+    def test_basic_initialization(self):
+        """Test basic parameter initialization."""
+        params = fx.YearAwareInvestParameters(
+            minimum_size=10,
+            maximum_size=100,
+        )
+
+        assert params.minimum_size == 10
+        assert params.maximum_size == 100
+        assert params.fixed_size is None
+        assert not params.allow_divestment
+        assert params.fixed_year_of_investment is None
+        assert params.fixed_year_of_decommissioning is None
+        assert params.fixed_duration is None
+
+    def test_fixed_size_initialization(self):
+        """Test initialization with fixed size."""
+        params = fx.YearAwareInvestParameters(fixed_size=50)
+
+        assert params.minimum_or_fixed_size == 50
+        assert params.maximum_or_fixed_size == 50
+        assert params.is_fixed_size
+
+    def test_timing_constraints_initialization(self):
+        """Test initialization with various timing constraints."""
+        params = fx.YearAwareInvestParameters(
+            fixed_year_of_investment=2,
+            minimum_duration=3,
+            maximum_duration=5,
+            earliest_year_of_decommissioning=4,
+        )
+
+        assert params.fixed_year_of_investment == 2
+        assert params.minimum_duration == 3
+        assert params.maximum_duration == 5
+        assert params.earliest_year_of_decommissioning == 4
+
+    def test_effects_initialization(self):
+        """Test initialization with effects."""
+        params = fx.YearAwareInvestParameters(
+            effects_of_investment={'costs': 1000},
+            effects_of_investment_per_size={'costs': 100},
+            allow_divestment=True,
+            effects_of_divestment={'costs': 500},
+            effects_of_divestment_per_size={'costs': 50},
+        )
+
+        assert params.effects_of_investment == {'costs': 1000}
+        assert params.effects_of_investment_per_size == {'costs': 100}
+        assert params.allow_divestment
+        assert params.effects_of_divestment == {'costs': 500}
+        assert params.effects_of_divestment_per_size == {'costs': 50}
+
+    def test_property_methods(self):
+        """Test property methods."""
+        # Test with fixed size
+        params_fixed = fx.YearAwareInvestParameters(fixed_size=50)
+        assert params_fixed.minimum_or_fixed_size == 50
+        assert params_fixed.maximum_or_fixed_size == 50
+        assert params_fixed.is_fixed_size
+
+        # Test with min/max size
+        params_range = fx.YearAwareInvestParameters(minimum_size=10, maximum_size=100)
+        assert params_range.minimum_or_fixed_size == 10
+        assert params_range.maximum_or_fixed_size == 100
+        assert not params_range.is_fixed_size
+
+
+class TestYearAwareInvestmentModelDirect:
+    """Test the YearAwareInvestmentModel class directly with linopy."""
+
+    def test_flow_invest_new(self, flow_system):
+        da = xr.DataArray(
+            [10] * 8,
+            coords=(flow_system.years_of_investment,),
+        ).expand_dims(year=flow_system.years)
+        da = da.where(da.year == da.year_of_investment).fillna(0)
+
+        flow = fx.Flow(
+            'Wärme',
+            bus='Fernwärme',
+            size=fx.InvestTimingParameters(
+                # year_of_decommissioning=2030,
+                minimum_lifetime=2,
+                maximum_lifetime=3,
+                minimum_size=9,
+                maximum_size=10,
+                specific_effects=xr.DataArray(
+                    [25, 30, 35, 40, 45, 50, 55, 60],
+                    coords=(flow_system.years,),
+                )
+                * -0,
+                # fix_effects=-2e3,
+                specific_effects_by_investment_year=-1 * da,
+            ),
+            relative_maximum=np.linspace(0.5, 1, flow_system.timesteps.size),
+        )
+
+        flow_system.add_elements(fx.Source('Source', source=flow))
+        calculation = fx.FullCalculation('GenericName', flow_system)
+        calculation.do_modeling()
+        # calculation.model.add_constraints(calculation.model['Source(Wärme)|is_invested'].sel(year=2022) == 1)
+        calculation.solve(fx.solvers.GurobiSolver(0, 60))
+
+        ds = calculation.results['Source'].solution
+        filtered_ds_year = ds[[v for v in ds.data_vars if ds[v].dims == ('year',)]]
+        print(filtered_ds_year.round(0).to_pandas().T)
+
+        filtered_ds_scalar = ds[[v for v in ds.data_vars if ds[v].dims == tuple()]]
+        print(filtered_ds_scalar.round(0).to_pandas().T)
+
+        print(calculation.results.solution['costs(invest)|total'].to_pandas())
+
+        print('##')


### PR DESCRIPTION
## Description
Adding InvestmentTiming to flixOpt.
This is not yet finished and needs some work. Including proper testing.
One identified major issue is:
- If an Investment occurs in a certain year which is representing multiple years, the investment costs are counted multiple times. This is wanted behavior for annual costs, but the actual investment costs/efffects are not are not happening in both years. This needs to be addressed before this is usable!!

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code refactoring

## Related Issues
Closes #(issue number)

## Testing
- [ ] I have tested my changes
- [x] Existing tests still pass

## Checklist
- [x] My code follows the project style
- [ ] I have updated documentation if needed
- [ ] I have added tests for new functionality (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduces time-based investment modeling with InvestTimingParameters and InvestmentTimingModel, including per-year effects, lifetimes, and decommissioning controls.
  - Adds year-aware modeling with a year_of_investment dimension and per-year durations; data-fitting and selection updated accordingly.
  - transform_data now supports an optional name_prefix across elements and interfaces.
- Improvements
  - Duration-aware on/off tracking and new utilities for bounding continuous changes and linking level changes to binaries.
  - Package now exposes InvestTimingParameters at the top level; investment reporting includes timing models.
  - Default weights respect per-year durations when available.
- Tests
  - Comprehensive tests for year-aware investments and annualized effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->