### PR TITLE
Add uv to CI

### DIFF
--- a/.github/workflows/python-app.yaml
+++ b/.github/workflows/python-app.yaml
@@ -112,7 +112,7 @@ jobs:
       - name: Run Bandit security scan
         run: |
           # Gate on HIGH severity & MEDIUM confidence; produce JSON artifact
-          uvx bandit -r flixopt/ -c pyproject.toml -f json -o bandit-report.json -q --severity-level HIGH --confidence-level MEDIUM
+          uvx bandit -r flixopt/ -c pyproject.toml -f json -o bandit-report.json -q --severity-level high --confidence-level medium
           # Human-readable output without affecting job status
           uvx bandit -r flixopt/ -c pyproject.toml -q --exit-zero
 


### PR DESCRIPTION
## Description
Brief description of the changes in this PR.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring

## Related Issues
Closes #(issue number)

## Testing
- [ ] I have tested my changes
- [ ] Existing tests still pass

## Checklist
- [x] My code follows the project style
- [x] I have updated documentation if needed
- [x] I have added tests for new functionality (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Standardized CI to use a universal UV setup across lint, test, security, release, publish, and docs workflows; enabled UV caching and non-interactive publish behavior; added flag to skip TestPyPI uploads.

- Tests
  - Unified venv handling and test/install flows under UV with improved retry and timeout handling for verifications.

- Security
  - Security scans migrated to UV-managed tooling with adjusted severity/confidence and unified execution environment (ubuntu-22.04).

- Documentation
  - Docs builds and dependencies now installed via UV-managed installs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->