### PR TITLE
Change UserWarning to DeprecationWarning for Bus objects which are st…

### DIFF
--- a/flixopt/flow_system.py
+++ b/flixopt/flow_system.py
@@ -417,14 +417,14 @@ class FlowSystem:
 
                 # Add Bus if not already added (deprecated)
                 if flow._bus_object is not None and flow._bus_object not in self.buses.values():
-                    self._add_buses(flow._bus_object)
                     warnings.warn(
                         f'The Bus {flow._bus_object.label} was added to the FlowSystem from {flow.label_full}.'
                         f'This is deprecated and will be removed in the future. '
                         f'Please pass the Bus.label to the Flow and the Bus to the FlowSystem instead.',
-                        UserWarning,
+                        DeprecationWarning,
                         stacklevel=1,
                     )
+                    self._add_buses(flow._bus_object)
 
                 # Connect Buses
                 bus = self.buses.get(flow.bus)


### PR DESCRIPTION
…ored inside Flows

## Description
Brief description of the changes in this PR.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring

## Related Issues
Closes #(issue number)

## Testing
- [ ] I have tested my changes
- [x] Existing tests still pass

## Checklist
- [x] My code follows the project style
- [x] I have updated documentation if needed
- [x] I have added tests for new functionality (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deprecation notices during flow-to-bus connection are now emitted as DeprecationWarning (instead of UserWarning), improving compatibility with warning filters. The warning is emitted before auto-registering the bus. No functional changes to connection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->