### PR TITLE
Feature/rename investparameter optional to mandatory

### DIFF
--- a/flixopt/elements.py
+++ b/flixopt/elements.py
@@ -489,7 +489,16 @@ class Flow(Element):
     @property
     def invest_is_optional(self) -> bool:
         # Wenn kein InvestParameters existiert: # Investment ist nicht optional -> Keine Variable --> False
+        warnings.warn(
+            "The 'invest_is_optional' property is deprecated. Use 'invest_is_mandatory' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return False if (isinstance(self.size, InvestParameters) and self.size.mandatory) else True
+
+    @property
+    def invest_is_mandatory(self) -> bool:
+        return False if (isinstance(self.size, InvestParameters) and not self.size.mandatory) else True
 
 
 class FlowModel(ElementModel):

--- a/flixopt/elements.py
+++ b/flixopt/elements.py
@@ -489,7 +489,7 @@ class Flow(Element):
     @property
     def invest_is_optional(self) -> bool:
         # Wenn kein InvestParameters existiert: # Investment ist nicht optional -> Keine Variable --> False
-        return False if (isinstance(self.size, InvestParameters) and not self.size.optional) else True
+        return False if (isinstance(self.size, InvestParameters) and self.size.mandatory) else True
 
 
 class FlowModel(ElementModel):
@@ -650,7 +650,7 @@ class FlowModel(ElementModel):
         if self.element.on_off_parameters is not None:
             return 0
         if isinstance(self.element.size, InvestParameters):
-            if self.element.size.optional:
+            if not self.element.size.mandatory:
                 return 0
             return self.flow_rate_lower_bound_relative * self.element.size.minimum_size
         return self.flow_rate_lower_bound_relative * self.element.size

--- a/flixopt/elements.py
+++ b/flixopt/elements.py
@@ -486,20 +486,6 @@ class Flow(Element):
         # Wenn kein InvestParameters existiert --> True; Wenn Investparameter, den Wert davon nehmen
         return False if (isinstance(self.size, InvestParameters) and self.size.fixed_size is None) else True
 
-    @property
-    def invest_is_optional(self) -> bool:
-        # Wenn kein InvestParameters existiert: # Investment ist nicht optional -> Keine Variable --> False
-        warnings.warn(
-            "The 'invest_is_optional' property is deprecated. Use 'invest_is_mandatory' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return False if (isinstance(self.size, InvestParameters) and self.size.mandatory) else True
-
-    @property
-    def invest_is_mandatory(self) -> bool:
-        return False if (isinstance(self.size, InvestParameters) and not self.size.mandatory) else True
-
 
 class FlowModel(ElementModel):
     def __init__(self, model: SystemModel, element: Flow):

--- a/flixopt/features.py
+++ b/flixopt/features.py
@@ -46,7 +46,7 @@ class InvestmentModel(Model):
         self.parameters = parameters
 
     def do_modeling(self):
-        if self.parameters.fixed_size and not self.parameters.optional:
+        if self.parameters.fixed_size and self.parameters.mandatory:
             self.size = self.add(
                 self._model.add_variables(
                     lower=self.parameters.fixed_size, upper=self.parameters.fixed_size, name=f'{self.label_full}|size'
@@ -56,15 +56,15 @@ class InvestmentModel(Model):
         else:
             self.size = self.add(
                 self._model.add_variables(
-                    lower=0 if self.parameters.optional else self.parameters.minimum_size,
+                    lower=0 if not self.parameters.mandatory else self.parameters.minimum_size,
                     upper=self.parameters.maximum_size,
                     name=f'{self.label_full}|size',
                 ),
                 'size',
             )
 
-        # Optional
-        if self.parameters.optional:
+        # Optional (not mandatory)
+        if not self.parameters.mandatory:
             self.is_invested = self.add(
                 self._model.add_variables(binary=True, name=f'{self.label_full}|is_invested'), 'is_invested'
             )
@@ -89,7 +89,7 @@ class InvestmentModel(Model):
                 target='invest',
             )
 
-        if self.parameters.divest_effects != {} and self.parameters.optional:
+        if self.parameters.divest_effects != {} and not self.parameters.mandatory:
             # share: divest_effects - isInvested * divest_effects
             self._model.effects.add_share_to_effects(
                 name=self.label_of_element,


### PR DESCRIPTION
## Description
Brief description of the changes in this PR.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Code refactoring

## Related Issues
#301 

## Testing
- [x] I have tested my changes
- [ ] Existing tests still pass

## Checklist
- [x] My code follows the project style
- [x] I have updated documentation if needed
- [x] I have added tests for new functionality (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a “mandatory” setting for investments, providing clearer control over required vs. optional sizing.
* **Deprecations**
  * The legacy “optional” parameter/property is deprecated; using it triggers a deprecation warning and maps to the new “mandatory” behavior.
* **Refactor**
  * Standardized sizing and divest behavior to depend on “mandatory” status: when not mandatory, lower bounds default to 0; when mandatory, minimum size applies. Fixed-size modeling now aligns with the mandatory flag.
* **Breaking Changes**
  * Removed a public property indicating optional investment on flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->