### PR TITLE
Remove examples from default CI for speedup

### DIFF
--- a/.github/workflows/python-app.yaml
+++ b/.github/workflows/python-app.yaml
@@ -85,10 +85,39 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv pip install --system .[dev] "pytest-xdist==3.*"
+          uv pip install --system .[dev]
 
       - name: Run tests
         run: pytest -v -p no:warnings --numprocesses=auto
+
+  test-examples:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    needs: lint
+    # Only run examples on releases (tags)
+    if: startsWith(github.ref, 'refs/tags/v')
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v5
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.8.19"
+          enable-cache: true
+
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install dependencies
+        run: |
+          uv pip install --system .[dev]
+
+      - name: Run example tests
+        run: pytest -v -p no:warnings -m examples
 
   security:
     name: Security Scan
@@ -129,7 +158,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
-    needs: [lint, test, security]
+    needs: [lint, test, test-examples, security]
     if: startsWith(github.ref, 'refs/tags/v')
 
     steps:
@@ -168,7 +197,7 @@ jobs:
   publish-testpypi:
     name: Publish to TestPyPI
     runs-on: ubuntu-24.04
-    needs: [test, create-release]  # Run after tests and release creation
+    needs: [test, test-examples, create-release]  # Run after tests and release creation
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')  # Only on tag push
     environment:
       name: testpypi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ full = [
 # Development tools and testing
 dev = [
     "pytest==8.4.2",
+    "pytest-xdist==3.8.0",
     "nbformat==5.10.4",
     "ruff==0.13.0",
     "pre-commit==4.3.0",
@@ -175,6 +176,13 @@ docstring-code-format = true
 
 [tool.ruff.lint.pyupgrade]
 keep-runtime-typing = false  # Allow pyupgrade to drop runtime typing; prefer postponed annotations
+
+[tool.pytest.ini_options]
+markers = [
+    "slow: marks tests as slow",
+    "examples: marks example tests (run only on releases)",
+]
+addopts = "-m 'not examples'"  # Skip examples by default
 
 [tool.bandit]
 skips = ["B101", "B506"]  # assert_used and yaml_load

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -16,7 +16,7 @@ EXAMPLES_DIR = Path(__file__).parent.parent / 'examples'
     ),  # Sort by parent and script name
     ids=lambda path: str(path.relative_to(EXAMPLES_DIR)),  # Show relative file paths
 )
-@pytest.mark.slow
+@pytest.mark.examples
 def test_example_scripts(example_script):
     """
     Test all example scripts in the examples directory.


### PR DESCRIPTION
## Description
Adds a new GitHub Actions job (test-examples) to run example tests on tag releases, updates job dependencies to include this job, introduces pytest markers/config (including skipping examples by default), adds pytest-xdist as a dev dependency, and retags example test from slow to examples.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Code refactoring

## Related Issues
Closes #(issue number)

## Testing
- [ ] I have tested my changes
- [ ] Existing tests still pass

## Checklist
- [x] My code follows the project style
- [x] I have updated documentation if needed
- [x] I have added tests for new functionality (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Added example test suite to run on tagged releases for stronger validation.
  - Introduced test markers (e.g., examples, slow) and default settings to skip example tests in routine runs.
- Chores
  - Streamlined CI setup by using standard dev dependency installation.
  - Updated workflow dependencies so publishing and release steps wait for example tests.
  - Improved release pipeline reliability without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->