### PR TITLE
Rename multiple parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,13 @@ Please keep the format of the changelog consistent with the other releases, so t
 ### ♻️ Changed
 
 ### 🗑️ Deprecated
+- Renamed `Effect` parameters:
+  - `minimum_investment` → `minimum_nontemporal`
+  - `maximum_investment` → `maximum_nontemporal`
+  - `minimum_operation` → `minimum_temporal`
+  - `maximum_operation` → `maximum_temporal`
+  - `minimum_operation_per_hour` → `minimum_per_hour`
+  - `maximum_operation_per_hour` → `maximum_per_hour`
 
 ### 🔥 Removed
 

--- a/examples/03_Calculation_types/example_calculation_types.py
+++ b/examples/03_Calculation_types/example_calculation_types.py
@@ -204,14 +204,14 @@ if __name__ == '__main__':
     ).write_html('results/BHKW2 Thermal Power.html')
 
     fx.plotting.with_plotly(
-        get_solutions(calculations, 'costs(operation)|total_per_timestep').to_dataframe(),
+        get_solutions(calculations, 'costs(temporal)|per_timestep').to_dataframe(),
         mode='line',
         title='Operation Cost Comparison',
         ylabel='Costs [€]',
     ).write_html('results/Operation Costs.html')
 
     fx.plotting.with_plotly(
-        pd.DataFrame(get_solutions(calculations, 'costs(operation)|total_per_timestep').to_dataframe().sum()).T,
+        pd.DataFrame(get_solutions(calculations, 'costs(temporal)|per_timestep').to_dataframe().sum()).T,
         mode='bar',
         title='Total Cost Comparison',
         ylabel='Costs [€]',

--- a/flixopt/calculation.py
+++ b/flixopt/calculation.py
@@ -80,8 +80,8 @@ class Calculation:
             'Penalty': float(self.model.effects.penalty.total.solution.values),
             'Effects': {
                 f'{effect.label} [{effect.unit}]': {
-                    'operation': float(effect.model.operation.total.solution.values),
-                    'invest': float(effect.model.invest.total.solution.values),
+                    'temporal': float(effect.model.temporal.total.solution.values),
+                    'nontemporal': float(effect.model.nontemporal.total.solution.values),
                     'total': float(effect.model.total.solution.values),
                 }
                 for effect in self.flow_system.effects

--- a/flixopt/components.py
+++ b/flixopt/components.py
@@ -975,7 +975,7 @@ class SourceAndSink(Component):
         prevent_simultaneous_sink_and_source = kwargs.pop('prevent_simultaneous_sink_and_source', None)
         if source is not None:
             warnings.warn(
-                'The use of the source argument is deprecated. Use the outputs argument instead.',
+                'The use of the "source" argument is deprecated. Use the "outputs" argument instead.',
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -985,7 +985,7 @@ class SourceAndSink(Component):
 
         if sink is not None:
             warnings.warn(
-                'The use of the sink argument is deprecated. Use the inputs argument instead.',
+                'The use of the "sink" argument is deprecated. Use the "inputs" argument instead.',
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -995,11 +995,14 @@ class SourceAndSink(Component):
 
         if prevent_simultaneous_sink_and_source is not None:
             warnings.warn(
-                'The use of the prevent_simultaneous_sink_and_source argument is deprecated. Use the prevent_simultaneous_flow_rates argument instead.',
+                'The use of the "prevent_simultaneous_sink_and_source" argument is deprecated. Use the "prevent_simultaneous_flow_rates" argument instead.',
                 DeprecationWarning,
                 stacklevel=2,
             )
             prevent_simultaneous_flow_rates = prevent_simultaneous_sink_and_source
+
+        # Validate any remaining unexpected kwargs
+        self._validate_kwargs(kwargs)
 
         super().__init__(
             label,
@@ -1125,13 +1128,16 @@ class Source(Component):
         source = kwargs.pop('source', None)
         if source is not None:
             warnings.warn(
-                'The use of the source argument is deprecated. Use the outputs argument instead.',
+                'The use of the "source" argument is deprecated. Use the "outputs" argument instead.',
                 DeprecationWarning,
                 stacklevel=2,
             )
             if outputs is not None:
                 raise ValueError('Either source or outputs can be specified, but not both.')
             outputs = [source]
+
+        # Validate any remaining unexpected kwargs
+        self._validate_kwargs(kwargs)
 
         self.prevent_simultaneous_flow_rates = prevent_simultaneous_flow_rates
         super().__init__(
@@ -1253,13 +1259,16 @@ class Sink(Component):
         sink = kwargs.pop('sink', None)
         if sink is not None:
             warnings.warn(
-                'The use of the sink argument is deprecated. Use the inputs argument instead.',
+                'The use of the "sink" argument is deprecated. Use the "inputs" argument instead.',
                 DeprecationWarning,
                 stacklevel=2,
             )
             if inputs is not None:
                 raise ValueError('Either sink or inputs can be specified, but not both.')
             inputs = [sink]
+
+        # Validate any remaining unexpected kwargs
+        self._validate_kwargs(kwargs)
 
         self.prevent_simultaneous_flow_rates = prevent_simultaneous_flow_rates
         super().__init__(

--- a/flixopt/elements.py
+++ b/flixopt/elements.py
@@ -575,7 +575,7 @@ class FlowModel(ElementModel):
                     effect: self.flow_rate * self._model.hours_per_step * factor.active_data
                     for effect, factor in self.element.effects_per_flow_hour.items()
                 },
-                target='operation',
+                target='temporal',
             )
 
     def _create_bounds_for_load_factor(self):

--- a/flixopt/elements.py
+++ b/flixopt/elements.py
@@ -486,11 +486,6 @@ class Flow(Element):
         # Wenn kein InvestParameters existiert --> True; Wenn Investparameter, den Wert davon nehmen
         return False if (isinstance(self.size, InvestParameters) and self.size.fixed_size is None) else True
 
-    @property
-    def invest_is_optional(self) -> bool:
-        # Wenn kein InvestParameters existiert: # Investment ist nicht optional -> Keine Variable --> False
-        return False if (isinstance(self.size, InvestParameters) and not self.size.optional) else True
-
 
 class FlowModel(ElementModel):
     def __init__(self, model: SystemModel, element: Flow):
@@ -650,7 +645,7 @@ class FlowModel(ElementModel):
         if self.element.on_off_parameters is not None:
             return 0
         if isinstance(self.element.size, InvestParameters):
-            if self.element.size.optional:
+            if not self.element.size.mandatory:
                 return 0
             return self.flow_rate_lower_bound_relative * self.element.size.minimum_size
         return self.flow_rate_lower_bound_relative * self.element.size

--- a/flixopt/features.py
+++ b/flixopt/features.py
@@ -46,7 +46,7 @@ class InvestmentModel(Model):
         self.parameters = parameters
 
     def do_modeling(self):
-        if self.parameters.fixed_size and not self.parameters.optional:
+        if self.parameters.fixed_size and self.parameters.mandatory:
             self.size = self.add(
                 self._model.add_variables(
                     lower=self.parameters.fixed_size, upper=self.parameters.fixed_size, name=f'{self.label_full}|size'
@@ -56,15 +56,15 @@ class InvestmentModel(Model):
         else:
             self.size = self.add(
                 self._model.add_variables(
-                    lower=0 if self.parameters.optional else self.parameters.minimum_size,
+                    lower=0 if not self.parameters.mandatory else self.parameters.minimum_size,
                     upper=self.parameters.maximum_size,
                     name=f'{self.label_full}|size',
                 ),
                 'size',
             )
 
-        # Optional
-        if self.parameters.optional:
+        # Optional (not mandatory)
+        if not self.parameters.mandatory:
             self.is_invested = self.add(
                 self._model.add_variables(binary=True, name=f'{self.label_full}|is_invested'), 'is_invested'
             )
@@ -89,7 +89,7 @@ class InvestmentModel(Model):
                 target='invest',
             )
 
-        if self.parameters.divest_effects != {} and self.parameters.optional:
+        if self.parameters.divest_effects != {} and not self.parameters.mandatory:
             # share: divest_effects - isInvested * divest_effects
             self._model.effects.add_share_to_effects(
                 name=self.label_of_element,

--- a/flixopt/features.py
+++ b/flixopt/features.py
@@ -86,7 +86,7 @@ class InvestmentModel(Model):
                     effect: self.is_invested * factor if self.is_invested is not None else factor
                     for effect, factor in fix_effects.items()
                 },
-                target='invest',
+                target='nontemporal',
             )
 
         if self.parameters.divest_effects != {} and not self.parameters.mandatory:
@@ -97,14 +97,14 @@ class InvestmentModel(Model):
                     effect: -self.is_invested * factor + factor
                     for effect, factor in self.parameters.divest_effects.items()
                 },
-                target='invest',
+                target='nontemporal',
             )
 
         if self.parameters.specific_effects != {}:
             self._model.effects.add_share_to_effects(
                 name=self.label_of_element,
                 expressions={effect: self.size * factor for effect, factor in self.parameters.specific_effects.items()},
-                target='invest',
+                target='nontemporal',
             )
 
         if self.parameters.piecewise_effects:
@@ -736,7 +736,7 @@ class OnOffModel(Model):
                     effect: self.state_model.on * factor * self._model.hours_per_step
                     for effect, factor in self.parameters.effects_per_running_hour.items()
                 },
-                target='operation',
+                target='temporal',
             )
 
         if self.parameters.effects_per_switch_on:
@@ -746,7 +746,7 @@ class OnOffModel(Model):
                     effect: self.switch_state_model.switch_on * factor
                     for effect, factor in self.parameters.effects_per_switch_on.items()
                 },
-                target='operation',
+                target='temporal',
             )
 
     @property
@@ -956,14 +956,12 @@ class ShareAllocationModel(Model):
     def do_modeling(self):
         self.total = self.add(
             self._model.add_variables(
-                lower=self._total_min, upper=self._total_max, coords=None, name=f'{self.label_full}|total'
+                lower=self._total_min, upper=self._total_max, coords=None, name=f'{self.label_full}'
             ),
             'total',
         )
         # eq: sum = sum(share_i) # skalar
-        self._eq_total = self.add(
-            self._model.add_constraints(self.total == 0, name=f'{self.label_full}|total'), 'total'
-        )
+        self._eq_total = self.add(self._model.add_constraints(self.total == 0, name=f'{self.label_full}'))
 
         if self._shares_are_time_series:
             self.total_per_timestep = self.add(
@@ -975,14 +973,14 @@ class ShareAllocationModel(Model):
                     if (self._max_per_hour is None)
                     else np.multiply(self._max_per_hour, self._model.hours_per_step),
                     coords=self._model.coords,
-                    name=f'{self.label_full}|total_per_timestep',
+                    name=f'{self.label_full}|per_timestep',
                 ),
-                'total_per_timestep',
+                'per_timestep',
             )
 
             self._eq_total_per_timestep = self.add(
-                self._model.add_constraints(self.total_per_timestep == 0, name=f'{self.label_full}|total_per_timestep'),
-                'total_per_timestep',
+                self._model.add_constraints(self.total_per_timestep == 0, name=f'{self.label_full}|per_timestep'),
+                'per_timestep',
             )
 
             # Add it to the total
@@ -1078,7 +1076,7 @@ class PiecewiseEffectsModel(Model):
         self._model.effects.add_share_to_effects(
             name=self.label_of_element,
             expressions={effect: variable * 1 for effect, variable in self.shares.items()},
-            target='invest',
+            target='nontemporal',
         )
 
 

--- a/flixopt/structure.py
+++ b/flixopt/structure.py
@@ -202,6 +202,36 @@ class Interface:
         """Serialize a dictionary of items."""
         return {k: self._serialize_value(v) for k, v in d.items()}
 
+    def _validate_kwargs(self, kwargs: dict, class_name: str = None) -> None:
+        """
+        Validate that no unexpected keyword arguments are present in kwargs.
+
+        This method uses inspect to get the actual function signature and filters out
+        any parameters that are not defined in the __init__ method, while also
+        handling the special case of 'kwargs' itself which can appear during deserialization.
+
+        Args:
+            kwargs: Dictionary of keyword arguments to validate
+            class_name: Optional class name for error messages. If None, uses self.__class__.__name__
+
+        Raises:
+            TypeError: If unexpected keyword arguments are found
+        """
+        if not kwargs:
+            return
+
+        import inspect
+
+        sig = inspect.signature(self.__init__)
+        known_params = set(sig.parameters.keys()) - {'self', 'kwargs'}
+        # Also filter out 'kwargs' itself which can appear during deserialization
+        extra_kwargs = {k: v for k, v in kwargs.items() if k not in known_params and k != 'kwargs'}
+
+        if extra_kwargs:
+            class_name = class_name or self.__class__.__name__
+            unexpected_params = ', '.join(f"'{param}'" for param in extra_kwargs.keys())
+            raise TypeError(f'{class_name}.__init__() got unexpected keyword argument(s): {unexpected_params}')
+
     @classmethod
     def _deserialize_dict(cls, data: dict) -> dict | Interface:
         if '__class__' in data:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,7 +62,7 @@ def simple_flow_system() -> fx.FlowSystem:
         'kg',
         'CO2_e-Emissionen',
         specific_share_to_other_effects_operation={costs.label: 0.2},
-        maximum_operation_per_hour=1000,
+        maximum_per_hour=1000,
     )
 
     # Create components

--- a/tests/test_effect.py
+++ b/tests/test_effect.py
@@ -15,39 +15,36 @@ class TestBusModel:
         model = create_linopy_model(flow_system)
 
         assert set(effect.model.variables) == {
-            'Effect1(invest)|total',
-            'Effect1(operation)|total',
-            'Effect1(operation)|total_per_timestep',
-            'Effect1|total',
+            'Effect1(nontemporal)',
+            'Effect1(temporal)',
+            'Effect1(temporal)|per_timestep',
+            'Effect1',
         }
         assert set(effect.model.constraints) == {
-            'Effect1(invest)|total',
-            'Effect1(operation)|total',
-            'Effect1(operation)|total_per_timestep',
-            'Effect1|total',
+            'Effect1(nontemporal)',
+            'Effect1(temporal)',
+            'Effect1(temporal)|per_timestep',
+            'Effect1',
         }
 
-        assert_var_equal(model.variables['Effect1|total'], model.add_variables())
-        assert_var_equal(model.variables['Effect1(invest)|total'], model.add_variables())
-        assert_var_equal(model.variables['Effect1(operation)|total'], model.add_variables())
-        assert_var_equal(
-            model.variables['Effect1(operation)|total_per_timestep'], model.add_variables(coords=(timesteps,))
-        )
+        assert_var_equal(model.variables['Effect1'], model.add_variables())
+        assert_var_equal(model.variables['Effect1(nontemporal)'], model.add_variables())
+        assert_var_equal(model.variables['Effect1(temporal)'], model.add_variables())
+        assert_var_equal(model.variables['Effect1(temporal)|per_timestep'], model.add_variables(coords=(timesteps,)))
 
         assert_conequal(
-            model.constraints['Effect1|total'],
-            model.variables['Effect1|total']
-            == model.variables['Effect1(operation)|total'] + model.variables['Effect1(invest)|total'],
+            model.constraints['Effect1'],
+            model.variables['Effect1']
+            == model.variables['Effect1(temporal)'] + model.variables['Effect1(nontemporal)'],
         )
-        assert_conequal(model.constraints['Effect1(invest)|total'], model.variables['Effect1(invest)|total'] == 0)
+        assert_conequal(model.constraints['Effect1(nontemporal)'], model.variables['Effect1(nontemporal)'] == 0)
         assert_conequal(
-            model.constraints['Effect1(operation)|total'],
-            model.variables['Effect1(operation)|total']
-            == model.variables['Effect1(operation)|total_per_timestep'].sum(),
+            model.constraints['Effect1(temporal)'],
+            model.variables['Effect1(temporal)'] == model.variables['Effect1(temporal)|per_timestep'].sum(),
         )
         assert_conequal(
-            model.constraints['Effect1(operation)|total_per_timestep'],
-            model.variables['Effect1(operation)|total_per_timestep'] == 0,
+            model.constraints['Effect1(temporal)|per_timestep'],
+            model.variables['Effect1(temporal)|per_timestep'] == 0,
         )
 
     def test_bounds(self, basic_flow_system_linopy):
@@ -57,56 +54,55 @@ class TestBusModel:
             'Effect1',
             '€',
             'Testing Effect',
-            minimum_operation=1.0,
-            maximum_operation=1.1,
-            minimum_invest=2.0,
-            maximum_invest=2.1,
+            minimum_temporal=1.0,
+            maximum_temporal=1.1,
+            minimum_nontemporal=2.0,
+            maximum_nontemporal=2.1,
             minimum_total=3.0,
             maximum_total=3.1,
-            minimum_operation_per_hour=4.0,
-            maximum_operation_per_hour=4.1,
+            minimum_per_hour=4.0,
+            maximum_per_hour=4.1,
         )
 
         flow_system.add_elements(effect)
         model = create_linopy_model(flow_system)
 
         assert set(effect.model.variables) == {
-            'Effect1(invest)|total',
-            'Effect1(operation)|total',
-            'Effect1(operation)|total_per_timestep',
-            'Effect1|total',
+            'Effect1(nontemporal)',
+            'Effect1(temporal)',
+            'Effect1(temporal)|per_timestep',
+            'Effect1',
         }
         assert set(effect.model.constraints) == {
-            'Effect1(invest)|total',
-            'Effect1(operation)|total',
-            'Effect1(operation)|total_per_timestep',
-            'Effect1|total',
+            'Effect1(nontemporal)',
+            'Effect1(temporal)',
+            'Effect1(temporal)|per_timestep',
+            'Effect1',
         }
 
-        assert_var_equal(model.variables['Effect1|total'], model.add_variables(lower=3.0, upper=3.1))
-        assert_var_equal(model.variables['Effect1(invest)|total'], model.add_variables(lower=2.0, upper=2.1))
-        assert_var_equal(model.variables['Effect1(operation)|total'], model.add_variables(lower=1.0, upper=1.1))
+        assert_var_equal(model.variables['Effect1'], model.add_variables(lower=3.0, upper=3.1))
+        assert_var_equal(model.variables['Effect1(nontemporal)'], model.add_variables(lower=2.0, upper=2.1))
+        assert_var_equal(model.variables['Effect1(temporal)'], model.add_variables(lower=1.0, upper=1.1))
         assert_var_equal(
-            model.variables['Effect1(operation)|total_per_timestep'],
+            model.variables['Effect1(temporal)|per_timestep'],
             model.add_variables(
                 lower=4.0 * model.hours_per_step, upper=4.1 * model.hours_per_step, coords=(timesteps,)
             ),
         )
 
         assert_conequal(
-            model.constraints['Effect1|total'],
-            model.variables['Effect1|total']
-            == model.variables['Effect1(operation)|total'] + model.variables['Effect1(invest)|total'],
+            model.constraints['Effect1'],
+            model.variables['Effect1']
+            == model.variables['Effect1(temporal)'] + model.variables['Effect1(nontemporal)'],
         )
-        assert_conequal(model.constraints['Effect1(invest)|total'], model.variables['Effect1(invest)|total'] == 0)
+        assert_conequal(model.constraints['Effect1(nontemporal)'], model.variables['Effect1(nontemporal)'] == 0)
         assert_conequal(
-            model.constraints['Effect1(operation)|total'],
-            model.variables['Effect1(operation)|total']
-            == model.variables['Effect1(operation)|total_per_timestep'].sum(),
+            model.constraints['Effect1(temporal)'],
+            model.variables['Effect1(temporal)'] == model.variables['Effect1(temporal)|per_timestep'].sum(),
         )
         assert_conequal(
-            model.constraints['Effect1(operation)|total_per_timestep'],
-            model.variables['Effect1(operation)|total_per_timestep'] == 0,
+            model.constraints['Effect1(temporal)|per_timestep'],
+            model.variables['Effect1(temporal)|per_timestep'] == 0,
         )
 
     def test_shares(self, basic_flow_system_linopy):
@@ -124,40 +120,41 @@ class TestBusModel:
         model = create_linopy_model(flow_system)
 
         assert set(effect2.model.variables) == {
-            'Effect2(invest)|total',
-            'Effect2(operation)|total',
-            'Effect2(operation)|total_per_timestep',
-            'Effect2|total',
-            'Effect1(invest)->Effect2(invest)',
-            'Effect1(operation)->Effect2(operation)',
+            'Effect2(nontemporal)',
+            'Effect2(temporal)',
+            'Effect2(temporal)|per_timestep',
+            'Effect2',
+            'Effect1(nontemporal)->Effect2(nontemporal)',
+            'Effect1(temporal)->Effect2(temporal)',
         }
         assert set(effect2.model.constraints) == {
-            'Effect2(invest)|total',
-            'Effect2(operation)|total',
-            'Effect2(operation)|total_per_timestep',
-            'Effect2|total',
-            'Effect1(invest)->Effect2(invest)',
-            'Effect1(operation)->Effect2(operation)',
+            'Effect2(nontemporal)',
+            'Effect2(temporal)',
+            'Effect2(temporal)|per_timestep',
+            'Effect2',
+            'Effect1(nontemporal)->Effect2(nontemporal)',
+            'Effect1(temporal)->Effect2(temporal)',
         }
 
         assert_conequal(
-            model.constraints['Effect2(invest)|total'],
-            model.variables['Effect2(invest)|total'] == model.variables['Effect1(invest)->Effect2(invest)'],
+            model.constraints['Effect2(nontemporal)'],
+            model.variables['Effect2(nontemporal)'] == model.variables['Effect1(nontemporal)->Effect2(nontemporal)'],
         )
 
         assert_conequal(
-            model.constraints['Effect2(operation)|total_per_timestep'],
-            model.variables['Effect2(operation)|total_per_timestep']
-            == model.variables['Effect1(operation)->Effect2(operation)'],
+            model.constraints['Effect2(temporal)|per_timestep'],
+            model.variables['Effect2(temporal)|per_timestep']
+            == model.variables['Effect1(temporal)->Effect2(temporal)'],
         )
 
         assert_conequal(
-            model.constraints['Effect1(operation)->Effect2(operation)'],
-            model.variables['Effect1(operation)->Effect2(operation)']
-            == model.variables['Effect1(operation)|total_per_timestep'] * 1.1,
+            model.constraints['Effect1(temporal)->Effect2(temporal)'],
+            model.variables['Effect1(temporal)->Effect2(temporal)']
+            == model.variables['Effect1(temporal)|per_timestep'] * 1.1,
         )
 
         assert_conequal(
-            model.constraints['Effect1(invest)->Effect2(invest)'],
-            model.variables['Effect1(invest)->Effect2(invest)'] == model.variables['Effect1(invest)|total'] * 2.1,
+            model.constraints['Effect1(nontemporal)->Effect2(nontemporal)'],
+            model.variables['Effect1(nontemporal)->Effect2(nontemporal)']
+            == model.variables['Effect1(nontemporal)'] * 2.1,
         )

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -99,18 +99,18 @@ class TestFlowModel:
         assert set(flow.model.variables) == {'Sink(Wärme)|total_flow_hours', 'Sink(Wärme)|flow_rate'}
         assert set(flow.model.constraints) == {'Sink(Wärme)|total_flow_hours'}
 
-        assert 'Sink(Wärme)->Costs(operation)' in set(costs.model.constraints)
-        assert 'Sink(Wärme)->CO2(operation)' in set(co2.model.constraints)
+        assert 'Sink(Wärme)->Costs(temporal)' in set(costs.model.constraints)
+        assert 'Sink(Wärme)->CO2(temporal)' in set(co2.model.constraints)
 
         assert_conequal(
-            model.constraints['Sink(Wärme)->Costs(operation)'],
-            model.variables['Sink(Wärme)->Costs(operation)']
+            model.constraints['Sink(Wärme)->Costs(temporal)'],
+            model.variables['Sink(Wärme)->Costs(temporal)']
             == flow.model.variables['Sink(Wärme)|flow_rate'] * model.hours_per_step * costs_per_flow_hour,
         )
 
         assert_conequal(
-            model.constraints['Sink(Wärme)->CO2(operation)'],
-            model.variables['Sink(Wärme)->CO2(operation)']
+            model.constraints['Sink(Wärme)->CO2(temporal)'],
+            model.variables['Sink(Wärme)->CO2(temporal)']
             == flow.model.variables['Sink(Wärme)|flow_rate'] * model.hours_per_step * co2_per_flow_hour,
         )
 
@@ -402,19 +402,19 @@ class TestFlowInvestModel:
         model = create_linopy_model(flow_system)
 
         # Check investment effects
-        assert 'Sink(Wärme)->Costs(invest)' in model.variables
-        assert 'Sink(Wärme)->CO2(invest)' in model.variables
+        assert 'Sink(Wärme)->Costs(nontemporal)' in model.variables
+        assert 'Sink(Wärme)->CO2(nontemporal)' in model.variables
 
         # Check fix effects (applied only when is_invested=1)
         assert_conequal(
-            model.constraints['Sink(Wärme)->Costs(invest)'],
-            model.variables['Sink(Wärme)->Costs(invest)']
+            model.constraints['Sink(Wärme)->Costs(nontemporal)'],
+            model.variables['Sink(Wärme)->Costs(nontemporal)']
             == flow.model.variables['Sink(Wärme)|is_invested'] * 1000 + flow.model.variables['Sink(Wärme)|size'] * 500,
         )
 
         assert_conequal(
-            model.constraints['Sink(Wärme)->CO2(invest)'],
-            model.variables['Sink(Wärme)->CO2(invest)']
+            model.constraints['Sink(Wärme)->CO2(nontemporal)'],
+            model.variables['Sink(Wärme)->CO2(nontemporal)']
             == flow.model.variables['Sink(Wärme)|is_invested'] * 5 + flow.model.variables['Sink(Wärme)|size'] * 0.1,
         )
 
@@ -437,11 +437,12 @@ class TestFlowInvestModel:
         model = create_linopy_model(flow_system)
 
         # Check divestment effects
-        assert 'Sink(Wärme)->Costs(invest)' in model.constraints
+        assert 'Sink(Wärme)->Costs(nontemporal)' in model.constraints
 
         assert_conequal(
-            model.constraints['Sink(Wärme)->Costs(invest)'],
-            model.variables['Sink(Wärme)->Costs(invest)'] + (model.variables['Sink(Wärme)|is_invested'] - 1) * 500 == 0,
+            model.constraints['Sink(Wärme)->Costs(nontemporal)'],
+            model.variables['Sink(Wärme)->Costs(nontemporal)'] + (model.variables['Sink(Wärme)|is_invested'] - 1) * 500
+            == 0,
         )
 
 
@@ -539,18 +540,18 @@ class TestFlowOnModel:
             'Sink(Wärme)|on_hours_total',
         }
 
-        assert 'Sink(Wärme)->Costs(operation)' in set(costs.model.constraints)
-        assert 'Sink(Wärme)->CO2(operation)' in set(co2.model.constraints)
+        assert 'Sink(Wärme)->Costs(temporal)' in set(costs.model.constraints)
+        assert 'Sink(Wärme)->CO2(temporal)' in set(co2.model.constraints)
 
         assert_conequal(
-            model.constraints['Sink(Wärme)->Costs(operation)'],
-            model.variables['Sink(Wärme)->Costs(operation)']
+            model.constraints['Sink(Wärme)->Costs(temporal)'],
+            model.variables['Sink(Wärme)->Costs(temporal)']
             == flow.model.variables['Sink(Wärme)|on'] * model.hours_per_step * costs_per_running_hour,
         )
 
         assert_conequal(
-            model.constraints['Sink(Wärme)->CO2(operation)'],
-            model.variables['Sink(Wärme)->CO2(operation)']
+            model.constraints['Sink(Wärme)->CO2(temporal)'],
+            model.variables['Sink(Wärme)->CO2(temporal)']
             == flow.model.variables['Sink(Wärme)|on'] * model.hours_per_step * co2_per_running_hour,
         )
 
@@ -885,12 +886,12 @@ class TestFlowOnModel:
         )
 
         # Check that startup cost effect constraint exists
-        assert 'Sink(Wärme)->Costs(operation)' in model.constraints
+        assert 'Sink(Wärme)->Costs(temporal)' in model.constraints
 
         # Verify the startup cost effect constraint
         assert_conequal(
-            model.constraints['Sink(Wärme)->Costs(operation)'],
-            model.variables['Sink(Wärme)->Costs(operation)'] == flow.model.variables['Sink(Wärme)|switch_on'] * 100,
+            model.constraints['Sink(Wärme)->Costs(temporal)'],
+            model.variables['Sink(Wärme)->Costs(temporal)'] == flow.model.variables['Sink(Wärme)|switch_on'] * 100,
         )
 
     def test_on_hours_limits(self, basic_flow_system_linopy):

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -112,7 +112,7 @@ def test_solve_and_load(solver_fixture, time_steps_fixture):
 
 def test_minimal_model(solver_fixture, time_steps_fixture):
     results = solve_and_load(flow_system_minimal(time_steps_fixture), solver_fixture)
-    assert_allclose(results.model.variables['costs|total'].solution.values, 80, rtol=1e-5, atol=1e-10)
+    assert_allclose(results.model.variables['costs'].solution.values, 80, rtol=1e-5, atol=1e-10)
 
     assert_allclose(
         results.model.variables['Boiler(Q_th)|flow_rate'].solution.values,
@@ -122,14 +122,14 @@ def test_minimal_model(solver_fixture, time_steps_fixture):
     )
 
     assert_allclose(
-        results.model.variables['costs(operation)|total_per_timestep'].solution.values,
+        results.model.variables['costs(temporal)|per_timestep'].solution.values,
         [-0.0, 20.0, 40.0, -0.0, 20.0],
         rtol=1e-5,
         atol=1e-10,
     )
 
     assert_allclose(
-        results.model.variables['Gastarif(Gas)->costs(operation)'].solution.values,
+        results.model.variables['Gastarif(Gas)->costs(temporal)'].solution.values,
         [-0.0, 20.0, 40.0, -0.0, 20.0],
         rtol=1e-5,
         atol=1e-10,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -63,11 +63,11 @@ class TestFlowSystem:
 
         # Verify key variables from loaded results
         assert_almost_equal_numeric(
-            results.solution['costs|total'].values,
+            results.solution['costs'].values,
             81.88394666666667,
             'costs doesnt match expected value',
         )
-        assert_almost_equal_numeric(results.solution['CO2|total'].values, 255.09184, 'CO2 doesnt match expected value')
+        assert_almost_equal_numeric(results.solution['CO2'].values, 255.09184, 'CO2 doesnt match expected value')
 
 
 class TestComponents:
@@ -179,13 +179,13 @@ class TestComplex:
 
         # Assertions
         assert_almost_equal_numeric(
-            calculation.results.model['costs|total'].solution.item(),
+            calculation.results.model['costs'].solution.item(),
             -11597.873624489237,
             'costs doesnt match expected value',
         )
 
         assert_almost_equal_numeric(
-            calculation.results.model['costs(operation)|total_per_timestep'].solution.values,
+            calculation.results.model['costs(temporal)|per_timestep'].solution.values,
             [
                 -2.38500000e03,
                 -2.21681333e03,
@@ -201,55 +201,55 @@ class TestComplex:
         )
 
         assert_almost_equal_numeric(
-            sum(calculation.results.model['CO2(operation)->costs(operation)'].solution.values),
+            sum(calculation.results.model['CO2(temporal)->costs(temporal)'].solution.values),
             258.63729669618675,
             'costs doesnt match expected value',
         )
         assert_almost_equal_numeric(
-            sum(calculation.results.model['Kessel(Q_th)->costs(operation)'].solution.values),
+            sum(calculation.results.model['Kessel(Q_th)->costs(temporal)'].solution.values),
             0.01,
             'costs doesnt match expected value',
         )
         assert_almost_equal_numeric(
-            sum(calculation.results.model['Kessel->costs(operation)'].solution.values),
+            sum(calculation.results.model['Kessel->costs(temporal)'].solution.values),
             -0.0,
             'costs doesnt match expected value',
         )
         assert_almost_equal_numeric(
-            sum(calculation.results.model['Gastarif(Q_Gas)->costs(operation)'].solution.values),
+            sum(calculation.results.model['Gastarif(Q_Gas)->costs(temporal)'].solution.values),
             39.09153113079115,
             'costs doesnt match expected value',
         )
         assert_almost_equal_numeric(
-            sum(calculation.results.model['Einspeisung(P_el)->costs(operation)'].solution.values),
+            sum(calculation.results.model['Einspeisung(P_el)->costs(temporal)'].solution.values),
             -14196.61245231646,
             'costs doesnt match expected value',
         )
         assert_almost_equal_numeric(
-            sum(calculation.results.model['KWK->costs(operation)'].solution.values),
+            sum(calculation.results.model['KWK->costs(temporal)'].solution.values),
             0.0,
             'costs doesnt match expected value',
         )
 
         assert_almost_equal_numeric(
-            calculation.results.model['Kessel(Q_th)->costs(invest)'].solution.values,
+            calculation.results.model['Kessel(Q_th)->costs(nontemporal)'].solution.values,
             1000 + 500,
             'costs doesnt match expected value',
         )
 
         assert_almost_equal_numeric(
-            calculation.results.model['Speicher->costs(invest)'].solution.values,
+            calculation.results.model['Speicher->costs(nontemporal)'].solution.values,
             800 + 1,
             'costs doesnt match expected value',
         )
 
         assert_almost_equal_numeric(
-            calculation.results.model['CO2(operation)|total'].solution.values,
+            calculation.results.model['CO2(temporal)'].solution.values,
             1293.1864834809337,
             'CO2 doesnt match expected value',
         )
         assert_almost_equal_numeric(
-            calculation.results.model['CO2(invest)|total'].solution.values,
+            calculation.results.model['CO2(nontemporal)'].solution.values,
             0.9999999999999994,
             'CO2 doesnt match expected value',
         )
@@ -407,13 +407,13 @@ class TestModelingTypes:
 
         if modeling_type in ['full', 'aggregated']:
             assert_almost_equal_numeric(
-                calc.results.model['costs|total'].solution.item(),
+                calc.results.model['costs'].solution.item(),
                 expected_costs[modeling_type],
                 f'Costs do not match for {modeling_type} modeling type',
             )
         else:
             assert_almost_equal_numeric(
-                calc.results.solution_without_overlap('costs(operation)|total_per_timestep').sum(),
+                calc.results.solution_without_overlap('costs(temporal)|per_timestep').sum(),
                 expected_costs[modeling_type],
                 f'Costs do not match for {modeling_type} modeling type',
             )

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -42,8 +42,8 @@ def test_flow_system_file_io(flow_system, highs_solver):
     )
 
     assert_almost_equal_numeric(
-        calculation_0.results.solution['costs|total'].values,
-        calculation_1.results.solution['costs|total'].values,
+        calculation_0.results.solution['costs'].values,
+        calculation_1.results.solution['costs'].values,
         'costs doesnt match expected value',
     )
 

--- a/tests/test_linear_converter.py
+++ b/tests/test_linear_converter.py
@@ -184,10 +184,10 @@ class TestLinearConverterModel:
         )
 
         # Check on_off effects
-        assert 'Converter->Costs(operation)' in model.constraints
+        assert 'Converter->Costs(temporal)' in model.constraints
         assert_conequal(
-            model.constraints['Converter->Costs(operation)'],
-            model.variables['Converter->Costs(operation)']
+            model.constraints['Converter->Costs(temporal)'],
+            model.variables['Converter->Costs(temporal)']
             == converter.model.on_off.variables['Converter|on'] * model.hours_per_step * 5,
         )
 
@@ -488,10 +488,10 @@ class TestLinearConverterModel:
         )
 
         # Verify that the costs effect is applied
-        assert 'Converter->Costs(operation)' in model.constraints
+        assert 'Converter->Costs(temporal)' in model.constraints
         assert_conequal(
-            model.constraints['Converter->Costs(operation)'],
-            model.variables['Converter->Costs(operation)']
+            model.constraints['Converter->Costs(temporal)'],
+            model.variables['Converter->Costs(temporal)']
             == converter.model.on_off.variables['Converter|on'] * model.hours_per_step * 5,
         )
 


### PR DESCRIPTION
* Change .optional to .mandatory

* Change .optional to .mandatory

* Remove not needed properties

## Description
Brief description of the changes in this PR.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring

## Related Issues
#301 #360 

## Testing
- [ ] I have tested my changes
- [ ] Existing tests still pass

## Checklist
- [x] My code follows the project style
- [x] I have updated documentation if needed
- [x] I have added tests for new functionality (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a “mandatory” investment option with a backwards-compatible “optional” alias that emits deprecation warnings.

- Refactor
  - Replaced invest/operation semantics with nontemporal/temporal naming across effects, results, shares, and constraints.
  - Modeling now uses mandatory vs. not-mandatory to determine sizing, bounds, and share/divest behavior; some result keys and plots are renamed accordingly.

- Chores
  - Removed a legacy public Flow property exposing investment optionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->