### PR TITLE
Feature/v3/feature/no warnings in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,12 @@ This replaces `specific_share_to_other_effects_*` parameters and inverts the dir
    * `fit_to_model_coords()` method for data alignment
    * `fit_effects_to_model_coords()` method for effect data processing
    * `connect_and_transform()` method replacing several operations
+* **Testing improvements**: Eliminated warnings during test execution
+  * Updated deprecated code patterns in tests and examples (e.g., `sink`/`source` → `inputs`/`outputs`, `'H'` → `'h'` frequency)
+  * Refactored plotting logic to handle test environments explicitly with non-interactive backends
+  * Added comprehensive warning filters in `__init__.py` and `pyproject.toml` to suppress third-party library warnings
+  * Improved test fixtures with proper figure cleanup to prevent memory leaks
+  * Enhanced backend detection and handling in `plotting.py` for both Matplotlib and Plotly
 
 
 Until here -->

--- a/examples/00_Minmal/minimal_example.py
+++ b/examples/00_Minmal/minimal_example.py
@@ -37,13 +37,15 @@ if __name__ == '__main__':
     # Heat load component with a fixed thermal demand profile
     heat_load = fx.Sink(
         'Heat Demand',
-        sink=fx.Flow(label='Thermal Load', bus='District Heating', size=1, fixed_relative_profile=thermal_load_profile),
+        inputs=[
+            fx.Flow(label='Thermal Load', bus='District Heating', size=1, fixed_relative_profile=thermal_load_profile)
+        ],
     )
 
     # Gas source component with cost-effect per flow hour
     gas_source = fx.Source(
         'Natural Gas Tariff',
-        source=fx.Flow(label='Gas Flow', bus='Natural Gas', size=1000, effects_per_flow_hour=0.04),  # 0.04 €/kWh
+        outputs=[fx.Flow(label='Gas Flow', bus='Natural Gas', size=1000, effects_per_flow_hour=0.04)],  # 0.04 €/kWh
     )
 
     # --- Build the Flow System ---

--- a/examples/01_Simple/simple_example.py
+++ b/examples/01_Simple/simple_example.py
@@ -37,7 +37,7 @@ if __name__ == '__main__':
         label='CO2',
         unit='kg',
         description='CO2_e-Emissionen',
-        maximum_operation_per_hour=1000,  # Max CO2 emissions per hour
+        maximum_per_hour=1000,  # Max CO2 emissions per hour
     )
 
     # --- Define Flow System Components ---
@@ -77,18 +77,20 @@ if __name__ == '__main__':
     # Heat Demand Sink: Represents a fixed heat demand profile
     heat_sink = fx.Sink(
         label='Heat Demand',
-        sink=fx.Flow(label='Q_th_Last', bus='Fernwärme', size=1, fixed_relative_profile=heat_demand_per_h),
+        inputs=[fx.Flow(label='Q_th_Last', bus='Fernwärme', size=1, fixed_relative_profile=heat_demand_per_h)],
     )
 
     # Gas Source: Gas tariff source with associated costs and CO2 emissions
     gas_source = fx.Source(
         label='Gastarif',
-        source=fx.Flow(label='Q_Gas', bus='Gas', size=1000, effects_per_flow_hour={costs.label: 0.04, CO2.label: 0.3}),
+        outputs=[
+            fx.Flow(label='Q_Gas', bus='Gas', size=1000, effects_per_flow_hour={costs.label: 0.04, CO2.label: 0.3})
+        ],
     )
 
     # Power Sink: Represents the export of electricity to the grid
     power_sink = fx.Sink(
-        label='Einspeisung', sink=fx.Flow(label='P_el', bus='Strom', effects_per_flow_hour=-1 * power_prices)
+        label='Einspeisung', inputs=[fx.Flow(label='P_el', bus='Strom', effects_per_flow_hour=-1 * power_prices)]
     )
 
     # --- Build the Flow System ---

--- a/examples/02_Complex/complex_example.py
+++ b/examples/02_Complex/complex_example.py
@@ -147,33 +147,39 @@ if __name__ == '__main__':
     # 5.a) Heat demand profile
     Waermelast = fx.Sink(
         'Wärmelast',
-        sink=fx.Flow(
-            'Q_th_Last',  # Heat sink
-            bus='Fernwärme',  # Linked bus
-            size=1,
-            fixed_relative_profile=heat_demand,  # Fixed demand profile
-        ),
+        inputs=[
+            fx.Flow(
+                'Q_th_Last',  # Heat sink
+                bus='Fernwärme',  # Linked bus
+                size=1,
+                fixed_relative_profile=heat_demand,  # Fixed demand profile
+            )
+        ],
     )
 
     # 5.b) Gas tariff
     Gasbezug = fx.Source(
         'Gastarif',
-        source=fx.Flow(
-            'Q_Gas',
-            bus='Gas',  # Gas source
-            size=1000,  # Nominal size
-            effects_per_flow_hour={Costs.label: 0.04, CO2.label: 0.3},
-        ),
+        outputs=[
+            fx.Flow(
+                'Q_Gas',
+                bus='Gas',  # Gas source
+                size=1000,  # Nominal size
+                effects_per_flow_hour={Costs.label: 0.04, CO2.label: 0.3},
+            )
+        ],
     )
 
     # 5.c) Feed-in of electricity
     Stromverkauf = fx.Sink(
         'Einspeisung',
-        sink=fx.Flow(
-            'P_el',
-            bus='Strom',  # Feed-in tariff for electricity
-            effects_per_flow_hour=-1 * electricity_price,  # Negative price for feed-in
-        ),
+        inputs=[
+            fx.Flow(
+                'P_el',
+                bus='Strom',  # Feed-in tariff for electricity
+                effects_per_flow_hour=-1 * electricity_price,  # Negative price for feed-in
+            )
+        ],
     )
 
     # --- Build FlowSystem ---

--- a/examples/03_Calculation_types/example_calculation_types.py
+++ b/examples/03_Calculation_types/example_calculation_types.py
@@ -108,39 +108,43 @@ if __name__ == '__main__':
     # 4. Sinks and Sources
     # Heat Load Profile
     a_waermelast = fx.Sink(
-        'Wärmelast', sink=fx.Flow('Q_th_Last', bus='Fernwärme', size=1, fixed_relative_profile=TS_heat_demand)
+        'Wärmelast', inputs=[fx.Flow('Q_th_Last', bus='Fernwärme', size=1, fixed_relative_profile=TS_heat_demand)]
     )
 
     # Electricity Feed-in
     a_strom_last = fx.Sink(
-        'Stromlast', sink=fx.Flow('P_el_Last', bus='Strom', size=1, fixed_relative_profile=TS_electricity_demand)
+        'Stromlast', inputs=[fx.Flow('P_el_Last', bus='Strom', size=1, fixed_relative_profile=TS_electricity_demand)]
     )
 
     # Gas Tariff
     a_gas_tarif = fx.Source(
         'Gastarif',
-        source=fx.Flow('Q_Gas', bus='Gas', size=1000, effects_per_flow_hour={costs.label: gas_price, CO2.label: 0.3}),
+        outputs=[
+            fx.Flow('Q_Gas', bus='Gas', size=1000, effects_per_flow_hour={costs.label: gas_price, CO2.label: 0.3})
+        ],
     )
 
     # Coal Tariff
     a_kohle_tarif = fx.Source(
         'Kohletarif',
-        source=fx.Flow('Q_Kohle', bus='Kohle', size=1000, effects_per_flow_hour={costs.label: 4.6, CO2.label: 0.3}),
+        outputs=[fx.Flow('Q_Kohle', bus='Kohle', size=1000, effects_per_flow_hour={costs.label: 4.6, CO2.label: 0.3})],
     )
 
     # Electricity Tariff and Feed-in
     a_strom_einspeisung = fx.Sink(
-        'Einspeisung', sink=fx.Flow('P_el', bus='Strom', size=1000, effects_per_flow_hour=TS_electricity_price_sell)
+        'Einspeisung', inputs=[fx.Flow('P_el', bus='Strom', size=1000, effects_per_flow_hour=TS_electricity_price_sell)]
     )
 
     a_strom_tarif = fx.Source(
         'Stromtarif',
-        source=fx.Flow(
-            'P_el',
-            bus='Strom',
-            size=1000,
-            effects_per_flow_hour={costs.label: TS_electricity_price_buy, CO2.label: 0.3},
-        ),
+        outputs=[
+            fx.Flow(
+                'P_el',
+                bus='Strom',
+                size=1000,
+                effects_per_flow_hour={costs.label: TS_electricity_price_buy, CO2.label: 0.3},
+            )
+        ],
     )
 
     # Flow System Setup

--- a/examples/04_Scenarios/scenario_example.py
+++ b/examples/04_Scenarios/scenario_example.py
@@ -43,7 +43,7 @@ if __name__ == '__main__':
         label='CO2',
         unit='kg',
         description='CO2_e-Emissionen',
-        maximum_operation_per_hour=1000,  # Max CO2 emissions per hour
+        maximum_per_hour=1000,  # Max CO2 emissions per hour
     )
 
     # --- Define Flow System Components ---
@@ -90,18 +90,20 @@ if __name__ == '__main__':
     # Heat Demand Sink: Represents a fixed heat demand profile
     heat_sink = fx.Sink(
         label='Heat Demand',
-        sink=fx.Flow(label='Q_th_Last', bus='Fernwärme', size=1, fixed_relative_profile=heat_demand_per_h),
+        inputs=[fx.Flow(label='Q_th_Last', bus='Fernwärme', size=1, fixed_relative_profile=heat_demand_per_h)],
     )
 
     # Gas Source: Gas tariff source with associated costs and CO2 emissions
     gas_source = fx.Source(
         label='Gastarif',
-        source=fx.Flow(label='Q_Gas', bus='Gas', size=1000, effects_per_flow_hour={costs.label: 0.04, CO2.label: 0.3}),
+        outputs=[
+            fx.Flow(label='Q_Gas', bus='Gas', size=1000, effects_per_flow_hour={costs.label: 0.04, CO2.label: 0.3})
+        ],
     )
 
     # Power Sink: Represents the export of electricity to the grid
     power_sink = fx.Sink(
-        label='Einspeisung', sink=fx.Flow(label='P_el', bus='Strom', effects_per_flow_hour=-1 * power_prices)
+        label='Einspeisung', inputs=[fx.Flow(label='P_el', bus='Strom', effects_per_flow_hour=-1 * power_prices)]
     )
 
     # --- Build the Flow System ---

--- a/examples/05_Two-stage-optimization/two_stage_optimization.py
+++ b/examples/05_Two-stage-optimization/two_stage_optimization.py
@@ -84,30 +84,34 @@ if __name__ == '__main__':
             charging=fx.Flow('Q_th_load', size=137, bus='Fernwärme'),
             discharging=fx.Flow('Q_th_unload', size=158, bus='Fernwärme'),
         ),
-        fx.Sink('Wärmelast', sink=fx.Flow('Q_th_Last', bus='Fernwärme', size=1, fixed_relative_profile=heat_demand)),
+        fx.Sink(
+            'Wärmelast', inputs=[fx.Flow('Q_th_Last', bus='Fernwärme', size=1, fixed_relative_profile=heat_demand)]
+        ),
         fx.Source(
             'Gastarif',
-            source=fx.Flow('Q_Gas', bus='Gas', size=1000, effects_per_flow_hour={'costs': gas_price, 'CO2': 0.3}),
+            outputs=[fx.Flow('Q_Gas', bus='Gas', size=1000, effects_per_flow_hour={'costs': gas_price, 'CO2': 0.3})],
         ),
         fx.Source(
             'Kohletarif',
-            source=fx.Flow('Q_Kohle', bus='Kohle', size=1000, effects_per_flow_hour={'costs': 4.6, 'CO2': 0.3}),
+            outputs=[fx.Flow('Q_Kohle', bus='Kohle', size=1000, effects_per_flow_hour={'costs': 4.6, 'CO2': 0.3})],
         ),
         fx.Source(
             'Einspeisung',
-            source=fx.Flow(
-                'P_el', bus='Strom', size=1000, effects_per_flow_hour={'costs': electricity_price + 0.5, 'CO2': 0.3}
-            ),
+            outputs=[
+                fx.Flow(
+                    'P_el', bus='Strom', size=1000, effects_per_flow_hour={'costs': electricity_price + 0.5, 'CO2': 0.3}
+                )
+            ],
         ),
         fx.Sink(
             'Stromlast',
-            sink=fx.Flow('P_el_Last', bus='Strom', size=1, fixed_relative_profile=electricity_demand),
+            inputs=[fx.Flow('P_el_Last', bus='Strom', size=1, fixed_relative_profile=electricity_demand)],
         ),
         fx.Source(
             'Stromtarif',
-            source=fx.Flow(
-                'P_el', bus='Strom', size=1000, effects_per_flow_hour={'costs': electricity_price, 'CO2': 0.3}
-            ),
+            outputs=[
+                fx.Flow('P_el', bus='Strom', size=1000, effects_per_flow_hour={'costs': electricity_price, 'CO2': 0.3})
+            ],
         ),
     )
 

--- a/flixopt/__init__.py
+++ b/flixopt/__init__.py
@@ -48,3 +48,7 @@ warnings.filterwarnings(
 )
 warnings.filterwarnings('ignore', message='Specify future_stack=True to adopt the new implementation', module='tsam')
 warnings.filterwarnings('ignore', message='Coordinates across variables not equal', module='linopy')
+warnings.filterwarnings('ignore', message='numpy.ndarray size changed', category=RuntimeWarning)
+warnings.filterwarnings(
+    'ignore', message="default value for join will change from join='outer' to join='exact'.", module='linopy'
+)

--- a/flixopt/__init__.py
+++ b/flixopt/__init__.py
@@ -41,14 +41,11 @@ CONFIG.load_config()
 
 
 # Suppress noisy third-party warnings that users can't fix
+warnings.filterwarnings('ignore', category=FutureWarning, module='tsam')
 warnings.filterwarnings(
-    'ignore',
-    message='A value is trying to be set on a copy of a DataFrame or Series through chained assignment',
-    module='tsam',
+    'ignore', category=UserWarning, message='Coordinates across variables not equal', module='linopy'
 )
-warnings.filterwarnings('ignore', message='Specify future_stack=True to adopt the new implementation', module='tsam')
-warnings.filterwarnings('ignore', message='Coordinates across variables not equal', module='linopy')
-warnings.filterwarnings('ignore', message='numpy.ndarray size changed', category=RuntimeWarning)
 warnings.filterwarnings(
     'ignore', message="default value for join will change from join='outer' to join='exact'.", module='linopy'
 )
+warnings.filterwarnings('ignore', message='numpy.ndarray size changed', category=RuntimeWarning)

--- a/flixopt/__init__.py
+++ b/flixopt/__init__.py
@@ -40,12 +40,31 @@ from .commons import (
 CONFIG.load_config()
 
 
-# Suppress noisy third-party warnings that users can't fix
+# === Runtime warning suppression for third-party libraries ===
+# These warnings are from dependencies and cannot be fixed by end users.
+# They are suppressed at runtime to provide a cleaner user experience.
+# These filters match the test configuration in pyproject.toml for consistency.
+
+# tsam: Time series aggregation library
+# - FutureWarning: Upcoming API changes in tsam (will be fixed in future tsam releases)
 warnings.filterwarnings('ignore', category=FutureWarning, module='tsam')
+# - UserWarning: Informational message about minimal value constraints
+warnings.filterwarnings('ignore', category=UserWarning, message='.*minimal value.*exceeds.*', module='tsam')
+# TODO: Might be able to fix it in flixopt?
+
+# linopy: Linear optimization library
+# - UserWarning: Coordinate mismatch warnings that don't affect functionality and are expected.
 warnings.filterwarnings(
     'ignore', category=UserWarning, message='Coordinates across variables not equal', module='linopy'
 )
+# - FutureWarning: join parameter default will change in future versions
 warnings.filterwarnings(
-    'ignore', message="default value for join will change from join='outer' to join='exact'.", module='linopy'
+    'ignore',
+    category=FutureWarning,
+    message="default value for join will change from join='outer' to join='exact'",
+    module='linopy',
 )
-warnings.filterwarnings('ignore', message='numpy.ndarray size changed', category=RuntimeWarning)
+
+# numpy: Core numerical library
+# - RuntimeWarning: Binary incompatibility warnings from compiled extensions (safe to ignore). numpy 1->2
+warnings.filterwarnings('ignore', category=RuntimeWarning, message='numpy\\.ndarray size changed')

--- a/flixopt/__init__.py
+++ b/flixopt/__init__.py
@@ -2,6 +2,7 @@
 This module bundles all common functionality of flixopt and sets up the logging
 """
 
+import warnings
 from importlib.metadata import version
 
 __version__ = version('flixopt')
@@ -37,3 +38,13 @@ from .commons import (
 )
 
 CONFIG.load_config()
+
+
+# Suppress noisy third-party warnings that users can't fix
+warnings.filterwarnings(
+    'ignore',
+    message='A value is trying to be set on a copy of a DataFrame or Series through chained assignment',
+    module='tsam',
+)
+warnings.filterwarnings('ignore', message='Specify future_stack=True to adopt the new implementation', module='tsam')
+warnings.filterwarnings('ignore', message='Coordinates across variables not equal', module='linopy')

--- a/flixopt/modeling.py
+++ b/flixopt/modeling.py
@@ -637,7 +637,7 @@ class BoundingPatterns:
         )
 
         transition_lower = model.add_constraints(
-            continuous_variable.isel({coord: slice(None, -1)}) - continuous_variable.isel({coord: slice(1, None)})
+            -(continuous_variable.isel({coord: slice(1, None)}) - continuous_variable.isel({coord: slice(None, -1)}))
             <= max_change * (switch_on.isel({coord: slice(1, None)}) + switch_off.isel({coord: slice(1, None)})),
             name=f'{name}|transition_lb',
         )

--- a/flixopt/plotting.py
+++ b/flixopt/plotting.py
@@ -1461,7 +1461,12 @@ def export_figure(
     elif isinstance(figure_like, tuple):
         fig, ax = figure_like
         if show:
-            fig.show()
+            # Only show if using interactive backend to avoid warnings in tests
+            import matplotlib
+
+            backend = matplotlib.get_backend().lower()
+            if backend not in ['agg', 'pdf', 'ps', 'svg', 'template']:
+                fig.show()
         if save:
             fig.savefig(str(filename), dpi=300)
         return fig, ax

--- a/flixopt/results.py
+++ b/flixopt/results.py
@@ -665,7 +665,7 @@ class CalculationResults:
 
                 component_arrays.append(arr.expand_dims(component=[component]))
 
-            ds[effect] = xr.concat(component_arrays, dim='component', coords='minimal').rename(effect)
+            ds[effect] = xr.concat(component_arrays, dim='component', coords='minimal', join='outer').rename(effect)
 
         # For now include a test to ensure correctness
         suffix = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,12 +193,11 @@ filterwarnings = [
     "error::FutureWarning:flixopt",
     "error::UserWarning:flixopt",
 
-    # === Third-party warnings (specific messages) ===
-    "ignore:A value is trying to be set on a copy of a DataFrame or Series through chained assignment:FutureWarning:tsam",
-    "ignore:Specify future_stack=True to adopt the new implementation:FutureWarning:tsam",
+    # === Third-party warnings (mirrored from __init__.py) ===
+    "ignore::FutureWarning:tsam",
     "ignore:Coordinates across variables not equal:UserWarning:linopy",
-    "ignore:numpy.ndarray size changed:RuntimeWarning",
     "ignore:.*default value for join will change from join='outer' to join='exact'.*:FutureWarning:linopy",
+    "ignore:numpy.ndarray size changed:RuntimeWarning",
 
     # === Expected/informational warnings ===
     "ignore:.*network visualization is still experimental.*:UserWarning",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,40 +184,6 @@ markers = [
 ]
 addopts = "-m 'not examples'"  # Skip examples by default
 
-# Warning filter configuration
-filterwarnings = [
-    # Treat most warnings as errors to catch issues early
-    "error",
-
-    # === Third-party library warnings we can't fix ===
-    # linopy/xarray FutureWarnings about join parameter changes
-    "ignore:In a future version of xarray:FutureWarning:linopy",
-    "ignore:.*join will change.*:FutureWarning:linopy",
-
-    # tsam/pandas FutureWarnings about DataFrame operations
-    "ignore:.*chained assignment.*:FutureWarning:tsam",
-    "ignore:.*implementation of stack.*:FutureWarning:tsam",
-    "ignore:.*inplace method.*:FutureWarning:tsam",
-
-    # linopy UserWarnings about coordinate misalignment (expected behavior)
-    "ignore:Coordinates across variables not equal.*:UserWarning:linopy",
-
-    # numpy RuntimeWarning about binary incompatibility (dependency issue)
-    "ignore:numpy.ndarray size changed.*:RuntimeWarning",
-
-    # === Expected/informational warnings ===
-    # Network visualization experimental warning
-    "ignore:.*network visualization is still experimental.*:UserWarning",
-
-    # tsam aggregation warnings (expected in certain scenarios)
-    "ignore:.*minimal value.*exceeds.*:UserWarning:tsam",
-
-    # === Show warnings from our own code (flixopt) ===
-    "default::DeprecationWarning:flixopt",
-    "default::UserWarning:flixopt",
-    "default::FutureWarning:flixopt",
-]
-
 [tool.bandit]
 skips = ["B101", "B506"]  # assert_used and yaml_load
 exclude_dirs = ["tests/"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,24 +186,13 @@ addopts = "-m 'not examples'"  # Skip examples by default
 
 # Warning filter configuration
 filterwarnings = [
-    # Treat most warnings as errors to catch issues early
-    "error",
+    # Default: Show all warnings (don't treat as errors by default)
+    "default",
 
-    # === Third-party library warnings we can't fix ===
-    # linopy/xarray FutureWarnings about join parameter changes
-    "ignore:In a future version of xarray:FutureWarning:linopy",
-    "ignore:.*join will change.*:FutureWarning:linopy",
-
-    # tsam/pandas FutureWarnings about DataFrame operations
-    "ignore:.*chained assignment.*:FutureWarning:tsam",
-    "ignore:.*implementation of stack.*:FutureWarning:tsam",
-    "ignore:.*inplace method.*:FutureWarning:tsam",
-
-    # linopy UserWarnings about coordinate misalignment (expected behavior)
-    "ignore:Coordinates across variables not equal.*:UserWarning:linopy",
-
-    # numpy RuntimeWarning about binary incompatibility (dependency issue)
-    "ignore:numpy.ndarray size changed.*:RuntimeWarning",
+    # === Treat OUR code warnings as errors (catch issues early) ===
+    "error::DeprecationWarning:flixopt",
+    "error::FutureWarning:flixopt",
+    "error::UserWarning:flixopt",
 
     # === Expected/informational warnings ===
     # Network visualization experimental warning
@@ -211,11 +200,6 @@ filterwarnings = [
 
     # tsam aggregation warnings (expected in certain scenarios)
     "ignore:.*minimal value.*exceeds.*:UserWarning:tsam",
-
-    # === Show warnings from our own code (flixopt) ===
-    "default::DeprecationWarning:flixopt",
-    "default::UserWarning:flixopt",
-    "default::FutureWarning:flixopt",
 ]
 
 [tool.bandit]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,6 +184,40 @@ markers = [
 ]
 addopts = "-m 'not examples'"  # Skip examples by default
 
+# Warning filter configuration
+filterwarnings = [
+    # Treat most warnings as errors to catch issues early
+    "error",
+
+    # === Third-party library warnings we can't fix ===
+    # linopy/xarray FutureWarnings about join parameter changes
+    "ignore:In a future version of xarray:FutureWarning:linopy",
+    "ignore:.*join will change.*:FutureWarning:linopy",
+
+    # tsam/pandas FutureWarnings about DataFrame operations
+    "ignore:.*chained assignment.*:FutureWarning:tsam",
+    "ignore:.*implementation of stack.*:FutureWarning:tsam",
+    "ignore:.*inplace method.*:FutureWarning:tsam",
+
+    # linopy UserWarnings about coordinate misalignment (expected behavior)
+    "ignore:Coordinates across variables not equal.*:UserWarning:linopy",
+
+    # numpy RuntimeWarning about binary incompatibility (dependency issue)
+    "ignore:numpy.ndarray size changed.*:RuntimeWarning",
+
+    # === Expected/informational warnings ===
+    # Network visualization experimental warning
+    "ignore:.*network visualization is still experimental.*:UserWarning",
+
+    # tsam aggregation warnings (expected in certain scenarios)
+    "ignore:.*minimal value.*exceeds.*:UserWarning:tsam",
+
+    # === Show warnings from our own code (flixopt) ===
+    "default::DeprecationWarning:flixopt",
+    "default::UserWarning:flixopt",
+    "default::FutureWarning:flixopt",
+]
+
 [tool.bandit]
 skips = ["B101", "B506"]  # assert_used and yaml_load
 exclude_dirs = ["tests/"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,21 +184,24 @@ markers = [
 ]
 addopts = "-m 'not examples'"  # Skip examples by default
 
-# Warning filter configuration
+# Warning filter configuration. Matching __init__.py
 filterwarnings = [
-    # Default: Show all warnings (don't treat as errors by default)
     "default",
 
-    # === Treat OUR code warnings as errors (catch issues early) ===
+    # === Treat OUR code warnings as errors ===
     "error::DeprecationWarning:flixopt",
     "error::FutureWarning:flixopt",
     "error::UserWarning:flixopt",
 
-    # === Expected/informational warnings ===
-    # Network visualization experimental warning
-    "ignore:.*network visualization is still experimental.*:UserWarning",
+    # === Third-party warnings (specific messages) ===
+    "ignore:A value is trying to be set on a copy of a DataFrame or Series through chained assignment:FutureWarning:tsam",
+    "ignore:Specify future_stack=True to adopt the new implementation:FutureWarning:tsam",
+    "ignore:Coordinates across variables not equal:UserWarning:linopy",
+    "ignore:numpy.ndarray size changed:RuntimeWarning",
+    "ignore:.*default value for join will change from join='outer' to join='exact'.*:FutureWarning:linopy",
 
-    # tsam aggregation warnings (expected in certain scenarios)
+    # === Expected/informational warnings ===
+    "ignore:.*network visualization is still experimental.*:UserWarning",
     "ignore:.*minimal value.*exceeds.*:UserWarning:tsam",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,24 +184,26 @@ markers = [
 ]
 addopts = "-m 'not examples'"  # Skip examples by default
 
-# Warning filter configuration. Matching __init__.py
+# Warning filter configuration for pytest
+# Filters are processed in order; first match wins
+# Format: "action:message:category:module"
 filterwarnings = [
+    # === Default behavior: show all warnings ===
     "default",
 
-    # === Treat OUR code warnings as errors ===
+    # === Treat flixopt warnings as errors (strict mode for our code) ===
+    # This ensures we catch deprecations, future changes, and user warnings in our own code
     "error::DeprecationWarning:flixopt",
     "error::FutureWarning:flixopt",
     "error::UserWarning:flixopt",
 
     # === Third-party warnings (mirrored from __init__.py) ===
     "ignore::FutureWarning:tsam",
-    "ignore:Coordinates across variables not equal:UserWarning:linopy",
-    "ignore:.*default value for join will change from join='outer' to join='exact'.*:FutureWarning:linopy",
-    "ignore:numpy.ndarray size changed:RuntimeWarning",
-
-    # === Expected/informational warnings ===
-    "ignore:.*network visualization is still experimental.*:UserWarning",
     "ignore:.*minimal value.*exceeds.*:UserWarning:tsam",
+    "ignore:Coordinates across variables not equal:UserWarning:linopy",
+    "ignore:default value for join will change from join='outer' to join='exact':FutureWarning:linopy",
+    "ignore:numpy\\.ndarray size changed:RuntimeWarning",
+    "ignore:.*network visualization is still experimental.*:UserWarning:flixopt",
 ]
 
 [tool.bandit]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -806,21 +806,16 @@ def assert_sets_equal(set1: Iterable, set2: Iterable, msg=''):
 @pytest.fixture(autouse=True)
 def cleanup_figures():
     """
-    Cleanup matplotlib and plotly figures after each test.
+    Cleanup matplotlib figures after each test.
 
     This fixture runs automatically after every test to:
     - Close all matplotlib figures to prevent memory leaks
-    - Reset plotly renderer to non-interactive mode
     """
     yield
     # Close all matplotlib figures
     import matplotlib.pyplot as plt
 
     plt.close('all')
-    # Set plotly to non-interactive renderer for tests
-    import plotly.io as pio
-
-    pio.renderers.default = 'json'
 
 
 @pytest.fixture(scope='session', autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -796,3 +796,43 @@ def assert_sets_equal(set1: Iterable, set2: Iterable, msg=''):
             error_msg = f'{msg}: {error_msg}'
 
         raise AssertionError(error_msg)
+
+
+# ============================================================================
+# PLOTTING CLEANUP FIXTURES
+# ============================================================================
+
+
+@pytest.fixture(autouse=True)
+def cleanup_figures():
+    """
+    Cleanup matplotlib and plotly figures after each test.
+
+    This fixture runs automatically after every test to:
+    - Close all matplotlib figures to prevent memory leaks
+    - Reset plotly renderer to non-interactive mode
+    """
+    yield
+    # Close all matplotlib figures
+    import matplotlib.pyplot as plt
+
+    plt.close('all')
+    # Set plotly to non-interactive renderer for tests
+    import plotly.io as pio
+
+    pio.renderers.default = 'json'
+
+
+@pytest.fixture(scope='session', autouse=True)
+def set_test_environment():
+    """
+    Configure plotting for test environment.
+
+    This fixture runs once per test session to:
+    - Set matplotlib to use non-interactive 'Agg' backend
+    - Prevent GUI windows from opening during tests
+    """
+    import matplotlib
+
+    matplotlib.use('Agg')  # Use non-interactive backend
+    yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -351,21 +351,21 @@ class Sinks:
     def heat_load(thermal_profile):
         """Create thermal heat load sink"""
         return fx.Sink(
-            'Wärmelast', sink=fx.Flow('Q_th_Last', bus='Fernwärme', size=1, fixed_relative_profile=thermal_profile)
+            'Wärmelast', inputs=[fx.Flow('Q_th_Last', bus='Fernwärme', size=1, fixed_relative_profile=thermal_profile)]
         )
 
     @staticmethod
     def electricity_feed_in(electrical_price_profile):
         """Create electricity feed-in sink"""
         return fx.Sink(
-            'Einspeisung', sink=fx.Flow('P_el', bus='Strom', effects_per_flow_hour=-1 * electrical_price_profile)
+            'Einspeisung', inputs=[fx.Flow('P_el', bus='Strom', effects_per_flow_hour=-1 * electrical_price_profile)]
         )
 
     @staticmethod
     def electricity_load(electrical_profile):
         """Create electrical load sink (for flow_system_long)"""
         return fx.Sink(
-            'Stromlast', sink=fx.Flow('P_el_Last', bus='Strom', size=1, fixed_relative_profile=electrical_profile)
+            'Stromlast', inputs=[fx.Flow('P_el_Last', bus='Strom', size=1, fixed_relative_profile=electrical_profile)]
         )
 
 
@@ -376,14 +376,14 @@ class Sources:
     def gas_with_costs_and_co2():
         """Standard gas tariff with CO2 emissions"""
         source = Sources.gas_with_costs()
-        source.source.effects_per_flow_hour = {'costs': 0.04, 'CO2': 0.3}
+        source.outputs[0].effects_per_flow_hour = {'costs': 0.04, 'CO2': 0.3}
         return source
 
     @staticmethod
     def gas_with_costs():
         """Simple gas tariff without CO2"""
         return fx.Source(
-            'Gastarif', source=fx.Flow(label='Q_Gas', bus='Gas', size=1000, effects_per_flow_hour={'costs': 0.04})
+            'Gastarif', outputs=[fx.Flow(label='Q_Gas', bus='Gas', size=1000, effects_per_flow_hour={'costs': 0.04})]
         )
 
 
@@ -405,7 +405,7 @@ def simple_flow_system() -> fx.FlowSystem:
     # Define effects
     costs = Effects.costs_with_co2_share()
     co2 = Effects.co2()
-    co2.maximum_operation_per_hour = 1000
+    co2.maximum_per_hour = 1000
 
     # Create components
     boiler = Converters.Boilers.simple()
@@ -436,7 +436,7 @@ def simple_flow_system_scenarios() -> fx.FlowSystem:
     # Define effects
     costs = Effects.costs_with_co2_share()
     co2 = Effects.co2()
-    co2.maximum_operation_per_hour = 1000
+    co2.maximum_per_hour = 1000
 
     # Create components
     boiler = Converters.Boilers.simple()
@@ -570,21 +570,23 @@ def flow_system_long():
         Effects.co2(),
         Effects.primary_energy(),
         fx.Sink(
-            'Wärmelast', sink=fx.Flow('Q_th_Last', bus='Fernwärme', size=1, fixed_relative_profile=thermal_load_ts)
+            'Wärmelast', inputs=[fx.Flow('Q_th_Last', bus='Fernwärme', size=1, fixed_relative_profile=thermal_load_ts)]
         ),
-        fx.Sink('Stromlast', sink=fx.Flow('P_el_Last', bus='Strom', size=1, fixed_relative_profile=electrical_load_ts)),
+        fx.Sink(
+            'Stromlast', inputs=[fx.Flow('P_el_Last', bus='Strom', size=1, fixed_relative_profile=electrical_load_ts)]
+        ),
         fx.Source(
             'Kohletarif',
-            source=fx.Flow('Q_Kohle', bus='Kohle', size=1000, effects_per_flow_hour={'costs': 4.6, 'CO2': 0.3}),
+            outputs=[fx.Flow('Q_Kohle', bus='Kohle', size=1000, effects_per_flow_hour={'costs': 4.6, 'CO2': 0.3})],
         ),
         fx.Source(
             'Gastarif',
-            source=fx.Flow('Q_Gas', bus='Gas', size=1000, effects_per_flow_hour={'costs': gas_price, 'CO2': 0.3}),
+            outputs=[fx.Flow('Q_Gas', bus='Gas', size=1000, effects_per_flow_hour={'costs': gas_price, 'CO2': 0.3})],
         ),
-        fx.Sink('Einspeisung', sink=fx.Flow('P_el', bus='Strom', size=1000, effects_per_flow_hour=p_feed_in)),
+        fx.Sink('Einspeisung', inputs=[fx.Flow('P_el', bus='Strom', size=1000, effects_per_flow_hour=p_feed_in)]),
         fx.Source(
             'Stromtarif',
-            source=fx.Flow('P_el', bus='Strom', size=1000, effects_per_flow_hour={'costs': p_sell, 'CO2': 0.3}),
+            outputs=[fx.Flow('P_el', bus='Strom', size=1000, effects_per_flow_hour={'costs': p_sell, 'CO2': 0.3})],
         ),
     )
 

--- a/tests/test_bus.py
+++ b/tests/test_bus.py
@@ -12,8 +12,8 @@ class TestBusModel:
         bus = fx.Bus('TestBus', excess_penalty_per_flow_hour=None)
         flow_system.add_elements(
             bus,
-            fx.Sink('WärmelastTest', sink=fx.Flow('Q_th_Last', 'TestBus')),
-            fx.Source('GastarifTest', source=fx.Flow('Q_Gas', 'TestBus')),
+            fx.Sink('WärmelastTest', inputs=[fx.Flow('Q_th_Last', 'TestBus')]),
+            fx.Source('GastarifTest', outputs=[fx.Flow('Q_Gas', 'TestBus')]),
         )
         model = create_linopy_model(flow_system)
 
@@ -31,8 +31,8 @@ class TestBusModel:
         bus = fx.Bus('TestBus')
         flow_system.add_elements(
             bus,
-            fx.Sink('WärmelastTest', sink=fx.Flow('Q_th_Last', 'TestBus')),
-            fx.Source('GastarifTest', source=fx.Flow('Q_Gas', 'TestBus')),
+            fx.Sink('WärmelastTest', inputs=[fx.Flow('Q_th_Last', 'TestBus')]),
+            fx.Source('GastarifTest', outputs=[fx.Flow('Q_Gas', 'TestBus')]),
         )
         model = create_linopy_model(flow_system)
 
@@ -73,8 +73,8 @@ class TestBusModel:
         bus = fx.Bus('TestBus', excess_penalty_per_flow_hour=None)
         flow_system.add_elements(
             bus,
-            fx.Sink('WärmelastTest', sink=fx.Flow('Q_th_Last', 'TestBus')),
-            fx.Source('GastarifTest', source=fx.Flow('Q_Gas', 'TestBus')),
+            fx.Sink('WärmelastTest', inputs=[fx.Flow('Q_th_Last', 'TestBus')]),
+            fx.Source('GastarifTest', outputs=[fx.Flow('Q_Gas', 'TestBus')]),
         )
         model = create_linopy_model(flow_system)
 

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -462,13 +462,15 @@ class TestTransmissionModel:
 
         last2 = fx.Sink(
             'Wärmelast2',
-            sink=fx.Flow(
-                'Q_th_Last',
-                bus='Wärme lokal',
-                size=1,
-                fixed_relative_profile=flow_system.components['Wärmelast'].sink.fixed_relative_profile
-                * np.array([0, 0, 0, 0, 0, 1, 1, 1, 1, 1]),
-            ),
+            inputs=[
+                fx.Flow(
+                    'Q_th_Last',
+                    bus='Wärme lokal',
+                    size=1,
+                    fixed_relative_profile=flow_system.components['Wärmelast'].inputs[0].fixed_relative_profile
+                    * np.array([0, 0, 0, 0, 0, 1, 1, 1, 1, 1]),
+                )
+            ],
         )
 
         transmission = fx.Transmission(
@@ -530,13 +532,15 @@ class TestTransmissionModel:
 
         last2 = fx.Sink(
             'Wärmelast2',
-            sink=fx.Flow(
-                'Q_th_Last',
-                bus='Wärme lokal',
-                size=1,
-                fixed_relative_profile=flow_system.components['Wärmelast'].sink.fixed_relative_profile
-                * np.array([0, 0, 0, 0, 0, 1, 1, 1, 1, 1]),
-            ),
+            inputs=[
+                fx.Flow(
+                    'Q_th_Last',
+                    bus='Wärme lokal',
+                    size=1,
+                    fixed_relative_profile=flow_system.components['Wärmelast'].inputs[0].fixed_relative_profile
+                    * np.array([0, 0, 0, 0, 0, 1, 1, 1, 1, 1]),
+                )
+            ],
         )
 
         transmission = fx.Transmission(

--- a/tests/test_dataconverter.py
+++ b/tests/test_dataconverter.py
@@ -910,7 +910,7 @@ class TestAdvancedBroadcasting:
         """Complex real-world scenario with multi-D array and broadcasting."""
         # Energy system data: time x technology, broadcast to regions
         coords = {
-            'time': pd.date_range('2024-01-01', periods=24, freq='H', name='time'),  # 24 hours
+            'time': pd.date_range('2024-01-01', periods=24, freq='h', name='time'),  # 24 hours
             'technology': pd.Index(['solar', 'wind', 'gas', 'coal'], name='technology'),  # 4 technologies
             'region': pd.Index(['north', 'south', 'east'], name='region'),  # 3 regions
         }

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -16,7 +16,7 @@ class TestFlowModel:
 
         flow = fx.Flow('Wärme', bus='Fernwärme', size=100)
 
-        flow_system.add_elements(fx.Sink('Sink', sink=flow))
+        flow_system.add_elements(fx.Sink('Sink', inputs=[flow]))
 
         model = create_linopy_model(flow_system)
 
@@ -54,7 +54,7 @@ class TestFlowModel:
             load_factor_max=0.9,
         )
 
-        flow_system.add_elements(fx.Sink('Sink', sink=flow))
+        flow_system.add_elements(fx.Sink('Sink', inputs=[flow]))
         model = create_linopy_model(flow_system)
 
         # total_flow_hours
@@ -112,7 +112,7 @@ class TestFlowModel:
         flow = fx.Flow(
             'Wärme', bus='Fernwärme', effects_per_flow_hour={'costs': costs_per_flow_hour, 'CO2': co2_per_flow_hour}
         )
-        flow_system.add_elements(fx.Sink('Sink', sink=flow), fx.Effect('CO2', 't', ''))
+        flow_system.add_elements(fx.Sink('Sink', inputs=[flow]), fx.Effect('CO2', 't', ''))
         model = create_linopy_model(flow_system)
         costs, co2 = flow_system.effects['costs'], flow_system.effects['CO2']
 
@@ -154,7 +154,7 @@ class TestFlowInvestModel:
             relative_maximum=np.linspace(0.5, 1, timesteps.size),
         )
 
-        flow_system.add_elements(fx.Sink('Sink', sink=flow))
+        flow_system.add_elements(fx.Sink('Sink', inputs=[flow]))
         model = create_linopy_model(flow_system)
 
         assert_sets_equal(
@@ -217,7 +217,7 @@ class TestFlowInvestModel:
             relative_maximum=np.linspace(0.5, 1, timesteps.size),
         )
 
-        flow_system.add_elements(fx.Sink('Sink', sink=flow))
+        flow_system.add_elements(fx.Sink('Sink', inputs=[flow]))
         model = create_linopy_model(flow_system)
 
         assert_sets_equal(
@@ -292,7 +292,7 @@ class TestFlowInvestModel:
             relative_maximum=np.linspace(0.5, 1, timesteps.size),
         )
 
-        flow_system.add_elements(fx.Sink('Sink', sink=flow))
+        flow_system.add_elements(fx.Sink('Sink', inputs=[flow]))
         model = create_linopy_model(flow_system)
 
         assert_sets_equal(
@@ -367,7 +367,7 @@ class TestFlowInvestModel:
             relative_maximum=np.linspace(0.5, 1, timesteps.size),
         )
 
-        flow_system.add_elements(fx.Sink('Sink', sink=flow))
+        flow_system.add_elements(fx.Sink('Sink', inputs=[flow]))
         model = create_linopy_model(flow_system)
 
         assert_sets_equal(
@@ -425,7 +425,7 @@ class TestFlowInvestModel:
             relative_maximum=0.9,
         )
 
-        flow_system.add_elements(fx.Sink('Sink', sink=flow))
+        flow_system.add_elements(fx.Sink('Sink', inputs=[flow]))
         model = create_linopy_model(flow_system)
 
         assert_sets_equal(
@@ -464,7 +464,7 @@ class TestFlowInvestModel:
             ),
         )
 
-        flow_system.add_elements(fx.Sink('Sink', sink=flow), co2)
+        flow_system.add_elements(fx.Sink('Sink', inputs=[flow]), co2)
         model = create_linopy_model(flow_system)
 
         # Check investment effects
@@ -501,7 +501,7 @@ class TestFlowInvestModel:
             ),
         )
 
-        flow_system.add_elements(fx.Sink('Sink', sink=flow))
+        flow_system.add_elements(fx.Sink('Sink', inputs=[flow]))
         model = create_linopy_model(flow_system)
 
         # Check divestment effects
@@ -528,7 +528,7 @@ class TestFlowOnModel:
             relative_maximum=0.8,
             on_off_parameters=fx.OnOffParameters(),
         )
-        flow_system.add_elements(fx.Sink('Sink', sink=flow))
+        flow_system.add_elements(fx.Sink('Sink', inputs=[flow]))
         model = create_linopy_model(flow_system)
 
         assert_sets_equal(
@@ -595,7 +595,7 @@ class TestFlowOnModel:
                 effects_per_running_hour={'costs': costs_per_running_hour, 'CO2': co2_per_running_hour}
             ),
         )
-        flow_system.add_elements(fx.Sink('Sink', sink=flow), fx.Effect('CO2', 't', ''))
+        flow_system.add_elements(fx.Sink('Sink', inputs=[flow]), fx.Effect('CO2', 't', ''))
         model = create_linopy_model(flow_system)
         costs, co2 = flow_system.effects['costs'], flow_system.effects['CO2']
 
@@ -655,7 +655,7 @@ class TestFlowOnModel:
             ),
         )
 
-        flow_system.add_elements(fx.Sink('Sink', sink=flow))
+        flow_system.add_elements(fx.Sink('Sink', inputs=[flow]))
         model = create_linopy_model(flow_system)
 
         assert {'Sink(Wärme)|consecutive_on_hours', 'Sink(Wärme)|on'}.issubset(set(flow.submodel.variables))
@@ -738,7 +738,7 @@ class TestFlowOnModel:
             previous_flow_rate=np.array([10, 20, 30, 0, 20, 20, 30]),  # Previously on for 3 steps
         )
 
-        flow_system.add_elements(fx.Sink('Sink', sink=flow))
+        flow_system.add_elements(fx.Sink('Sink', inputs=[flow]))
         model = create_linopy_model(flow_system)
 
         assert {'Sink(Wärme)|consecutive_on_hours', 'Sink(Wärme)|on'}.issubset(set(flow.submodel.variables))
@@ -818,7 +818,7 @@ class TestFlowOnModel:
             ),
         )
 
-        flow_system.add_elements(fx.Sink('Sink', sink=flow))
+        flow_system.add_elements(fx.Sink('Sink', inputs=[flow]))
         model = create_linopy_model(flow_system)
 
         assert {'Sink(Wärme)|consecutive_off_hours', 'Sink(Wärme)|off'}.issubset(set(flow.submodel.variables))
@@ -901,7 +901,7 @@ class TestFlowOnModel:
             previous_flow_rate=np.array([10, 20, 30, 0, 20, 0, 0]),  # Previously off for 2 steps
         )
 
-        flow_system.add_elements(fx.Sink('Sink', sink=flow))
+        flow_system.add_elements(fx.Sink('Sink', inputs=[flow]))
         model = create_linopy_model(flow_system)
 
         assert {'Sink(Wärme)|consecutive_off_hours', 'Sink(Wärme)|off'}.issubset(set(flow.submodel.variables))
@@ -983,7 +983,7 @@ class TestFlowOnModel:
             ),
         )
 
-        flow_system.add_elements(fx.Sink('Sink', sink=flow))
+        flow_system.add_elements(fx.Sink('Sink', inputs=[flow]))
         model = create_linopy_model(flow_system)
 
         # Check that variables exist
@@ -1045,7 +1045,7 @@ class TestFlowOnModel:
             ),
         )
 
-        flow_system.add_elements(fx.Sink('Sink', sink=flow))
+        flow_system.add_elements(fx.Sink('Sink', inputs=[flow]))
         model = create_linopy_model(flow_system)
 
         # Check that variables exist
@@ -1081,7 +1081,7 @@ class TestFlowOnInvestModel:
             relative_maximum=0.8,
             on_off_parameters=fx.OnOffParameters(),
         )
-        flow_system.add_elements(fx.Sink('Sink', sink=flow))
+        flow_system.add_elements(fx.Sink('Sink', inputs=[flow]))
         model = create_linopy_model(flow_system)
 
         assert_sets_equal(
@@ -1182,7 +1182,7 @@ class TestFlowOnInvestModel:
             relative_maximum=0.8,
             on_off_parameters=fx.OnOffParameters(),
         )
-        flow_system.add_elements(fx.Sink('Sink', sink=flow))
+        flow_system.add_elements(fx.Sink('Sink', inputs=[flow]))
         model = create_linopy_model(flow_system)
 
         assert_sets_equal(
@@ -1281,7 +1281,7 @@ class TestFlowWithFixedProfile:
             fixed_relative_profile=profile,
         )
 
-        flow_system.add_elements(fx.Sink('Sink', sink=flow))
+        flow_system.add_elements(fx.Sink('Sink', inputs=[flow]))
         model = create_linopy_model(flow_system)
 
         assert_var_equal(
@@ -1308,7 +1308,7 @@ class TestFlowWithFixedProfile:
             fixed_relative_profile=profile,
         )
 
-        flow_system.add_elements(fx.Sink('Sink', sink=flow))
+        flow_system.add_elements(fx.Sink('Sink', inputs=[flow]))
         model = create_linopy_model(flow_system)
 
         assert_var_equal(

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -73,9 +73,9 @@ def flow_system_base(timesteps: pd.DatetimeIndex) -> fx.FlowSystem:
     flow_system.add_elements(
         fx.Sink(
             label='Wärmelast',
-            sink=fx.Flow(label='Wärme', bus='Fernwärme', fixed_relative_profile=data.thermal_demand, size=1),
+            inputs=[fx.Flow(label='Wärme', bus='Fernwärme', fixed_relative_profile=data.thermal_demand, size=1)],
         ),
-        fx.Source(label='Gastarif', source=fx.Flow(label='Gas', bus='Gas', effects_per_flow_hour=1)),
+        fx.Source(label='Gastarif', outputs=[fx.Flow(label='Gas', bus='Gas', effects_per_flow_hour=1)]),
     )
     return flow_system
 
@@ -551,7 +551,7 @@ def test_on_total_bounds(solver_fixture, time_steps_fixture):
             ),
         ),
     )
-    flow_system.all_elements['Wärmelast'].sink.fixed_relative_profile = np.array(
+    flow_system.all_elements['Wärmelast'].inputs[0].fixed_relative_profile = np.array(
         [0, 10, 20, 0, 12]
     )  # Else its non deterministic
 
@@ -620,7 +620,7 @@ def test_consecutive_on_off(solver_fixture, time_steps_fixture):
             Q_th=fx.Flow('Q_th', bus='Fernwärme', size=100),
         ),
     )
-    flow_system.all_elements['Wärmelast'].sink.fixed_relative_profile = np.array([5, 10, 20, 18, 12])
+    flow_system.all_elements['Wärmelast'].inputs[0].fixed_relative_profile = np.array([5, 10, 20, 18, 12])
     # Else its non deterministic
 
     solve_and_load(flow_system, solver_fixture)
@@ -682,7 +682,7 @@ def test_consecutive_off(solver_fixture, time_steps_fixture):
             ),
         ),
     )
-    flow_system.all_elements['Wärmelast'].sink.fixed_relative_profile = np.array(
+    flow_system.all_elements['Wärmelast'].inputs[0].fixed_relative_profile = np.array(
         [5, 0, 20, 18, 12]
     )  # Else its non deterministic
 

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -4,21 +4,12 @@ Manual test script for plots
 
 import unittest
 
-import matplotlib
-
-matplotlib.use('Agg')  # Use non-interactive backend
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import plotly.io as pio
 import pytest
 
 from flixopt import plotting
-
-# Configure plotly to use a renderer that doesn't leave sockets open
-# 'browser' opens system browser but may leave connections open
-# Using 'json' for tests to avoid ResourceWarnings
-pio.renderers.default = 'json'
 
 
 @pytest.mark.slow

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -4,13 +4,19 @@ Manual test script for plots
 
 import unittest
 
+import matplotlib
+
+matplotlib.use('Agg')  # Use non-interactive backend
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import plotly
+import plotly.io as pio
 import pytest
 
 from flixopt import plotting
+
+# Configure plotly to render in browser instead of external windows
+pio.renderers.default = 'browser'
 
 
 @pytest.mark.slow
@@ -51,38 +57,42 @@ class TestPlots(unittest.TestCase):
 
     def test_bar_plots(self):
         data = self.get_sample_data(nr_of_columns=10, nr_of_periods=1, time_steps_per_period=24)
-        plotly.offline.plot(plotting.with_plotly(data, 'stacked_bar'))
+        plotting.with_plotly(data, 'stacked_bar').show()
         plotting.with_matplotlib(data, 'stacked_bar')
-        plt.show()
+        plt.savefig(f'test_plot_{self._testMethodName}.png', bbox_inches='tight')
+        plt.close('all')  # Close all figures to prevent memory leaks
 
         data = self.get_sample_data(
             nr_of_columns=10, nr_of_periods=5, time_steps_per_period=24, drop_fraction_of_indices=0.3
         )
-        plotly.offline.plot(plotting.with_plotly(data, 'stacked_bar'))
+        plotting.with_plotly(data, 'stacked_bar').show()
         plotting.with_matplotlib(data, 'stacked_bar')
-        plt.show()
+        plt.savefig(f'test_plot_{self._testMethodName}.png', bbox_inches='tight')
+        plt.close('all')  # Close all figures to prevent memory leaks
 
     def test_line_plots(self):
         data = self.get_sample_data(nr_of_columns=10, nr_of_periods=1, time_steps_per_period=24)
-        plotly.offline.plot(plotting.with_plotly(data, 'line'))
+        plotting.with_plotly(data, 'line').show()
         plotting.with_matplotlib(data, 'line')
-        plt.show()
+        plt.savefig(f'test_plot_{self._testMethodName}.png', bbox_inches='tight')
+        plt.close('all')  # Close all figures to prevent memory leaks
 
         data = self.get_sample_data(
             nr_of_columns=10, nr_of_periods=5, time_steps_per_period=24, drop_fraction_of_indices=0.3
         )
-        plotly.offline.plot(plotting.with_plotly(data, 'line'))
+        plotting.with_plotly(data, 'line').show()
         plotting.with_matplotlib(data, 'line')
-        plt.show()
+        plt.savefig(f'test_plot_{self._testMethodName}.png', bbox_inches='tight')
+        plt.close('all')  # Close all figures to prevent memory leaks
 
     def test_stacked_line_plots(self):
         data = self.get_sample_data(nr_of_columns=10, nr_of_periods=1, time_steps_per_period=24)
-        plotly.offline.plot(plotting.with_plotly(data, 'area'))
+        plotting.with_plotly(data, 'area').show()
 
         data = self.get_sample_data(
             nr_of_columns=10, nr_of_periods=5, time_steps_per_period=24, drop_fraction_of_indices=0.3
         )
-        plotly.offline.plot(plotting.with_plotly(data, 'area'))
+        plotting.with_plotly(data, 'area').show()
 
     def test_heat_map_plots(self):
         # Generate single-column data with datetime index for heatmap
@@ -91,9 +101,10 @@ class TestPlots(unittest.TestCase):
         # Convert data for heatmap plotting using 'day' as period and 'hour' steps
         heatmap_data = plotting.reshape_to_2d(data.iloc[:, 0].values.flatten(), 24)
         # Plotting heatmaps with Plotly and Matplotlib
-        plotly.offline.plot(plotting.heat_map_plotly(pd.DataFrame(heatmap_data)))
+        plotting.heat_map_plotly(pd.DataFrame(heatmap_data)).show()
         plotting.heat_map_matplotlib(pd.DataFrame(heatmap_data))
-        plt.show()
+        plt.savefig(f'test_plot_{self._testMethodName}.png', bbox_inches='tight')
+        plt.close('all')  # Close all figures to prevent memory leaks
 
     def test_heat_map_plots_resampling(self):
         date_range = pd.date_range(start='2023-01-01', end='2023-03-21', freq='5min')
@@ -113,21 +124,24 @@ class TestPlots(unittest.TestCase):
         data = df_irregular
         # Convert data for heatmap plotting using 'day' as period and 'hour' steps
         heatmap_data = plotting.heat_map_data_from_df(data, 'MS', 'D')
-        plotly.offline.plot(plotting.heat_map_plotly(heatmap_data))
+        plotting.heat_map_plotly(heatmap_data).show()
         plotting.heat_map_matplotlib(pd.DataFrame(heatmap_data))
-        plt.show()
+        plt.savefig(f'test_plot_{self._testMethodName}.png', bbox_inches='tight')
+        plt.close('all')  # Close all figures to prevent memory leaks
 
         heatmap_data = plotting.heat_map_data_from_df(data, 'W', 'h', fill='ffill')
         # Plotting heatmaps with Plotly and Matplotlib
-        plotly.offline.plot(plotting.heat_map_plotly(pd.DataFrame(heatmap_data)))
+        plotting.heat_map_plotly(pd.DataFrame(heatmap_data)).show()
         plotting.heat_map_matplotlib(pd.DataFrame(heatmap_data))
-        plt.show()
+        plt.savefig(f'test_plot_{self._testMethodName}.png', bbox_inches='tight')
+        plt.close('all')  # Close all figures to prevent memory leaks
 
         heatmap_data = plotting.heat_map_data_from_df(data, 'D', 'h', fill='ffill')
         # Plotting heatmaps with Plotly and Matplotlib
-        plotly.offline.plot(plotting.heat_map_plotly(pd.DataFrame(heatmap_data)))
+        plotting.heat_map_plotly(pd.DataFrame(heatmap_data)).show()
         plotting.heat_map_matplotlib(pd.DataFrame(heatmap_data))
-        plt.show()
+        plt.savefig(f'test_plot_{self._testMethodName}.png', bbox_inches='tight')
+        plt.close('all')  # Close all figures to prevent memory leaks
 
 
 if __name__ == '__main__':

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -15,14 +15,24 @@ import pytest
 
 from flixopt import plotting
 
-# Configure plotly to render in browser instead of external windows
-pio.renderers.default = 'browser'
+# Configure plotly to use a renderer that doesn't leave sockets open
+# 'browser' opens system browser but may leave connections open
+# Using 'json' for tests to avoid ResourceWarnings
+pio.renderers.default = 'json'
 
 
 @pytest.mark.slow
 class TestPlots(unittest.TestCase):
     def setUp(self):
         np.random.seed(72)
+
+    def tearDown(self):
+        """Cleanup matplotlib and plotly resources"""
+        plt.close('all')
+        # Force garbage collection to cleanup any lingering resources
+        import gc
+
+        gc.collect()
 
     @staticmethod
     def get_sample_data(
@@ -57,7 +67,8 @@ class TestPlots(unittest.TestCase):
 
     def test_bar_plots(self):
         data = self.get_sample_data(nr_of_columns=10, nr_of_periods=1, time_steps_per_period=24)
-        plotting.with_plotly(data, 'stacked_bar').show()
+        # Create plotly figure (json renderer doesn't need .show())
+        _ = plotting.with_plotly(data, 'stacked_bar')
         plotting.with_matplotlib(data, 'stacked_bar')
         plt.savefig(f'test_plot_{self._testMethodName}.png', bbox_inches='tight')
         plt.close('all')  # Close all figures to prevent memory leaks
@@ -65,14 +76,15 @@ class TestPlots(unittest.TestCase):
         data = self.get_sample_data(
             nr_of_columns=10, nr_of_periods=5, time_steps_per_period=24, drop_fraction_of_indices=0.3
         )
-        plotting.with_plotly(data, 'stacked_bar').show()
+        # Create plotly figure (json renderer doesn't need .show())
+        _ = plotting.with_plotly(data, 'stacked_bar')
         plotting.with_matplotlib(data, 'stacked_bar')
         plt.savefig(f'test_plot_{self._testMethodName}.png', bbox_inches='tight')
         plt.close('all')  # Close all figures to prevent memory leaks
 
     def test_line_plots(self):
         data = self.get_sample_data(nr_of_columns=10, nr_of_periods=1, time_steps_per_period=24)
-        plotting.with_plotly(data, 'line').show()
+        _ = plotting.with_plotly(data, 'line')
         plotting.with_matplotlib(data, 'line')
         plt.savefig(f'test_plot_{self._testMethodName}.png', bbox_inches='tight')
         plt.close('all')  # Close all figures to prevent memory leaks
@@ -80,19 +92,19 @@ class TestPlots(unittest.TestCase):
         data = self.get_sample_data(
             nr_of_columns=10, nr_of_periods=5, time_steps_per_period=24, drop_fraction_of_indices=0.3
         )
-        plotting.with_plotly(data, 'line').show()
+        _ = plotting.with_plotly(data, 'line')
         plotting.with_matplotlib(data, 'line')
         plt.savefig(f'test_plot_{self._testMethodName}.png', bbox_inches='tight')
         plt.close('all')  # Close all figures to prevent memory leaks
 
     def test_stacked_line_plots(self):
         data = self.get_sample_data(nr_of_columns=10, nr_of_periods=1, time_steps_per_period=24)
-        plotting.with_plotly(data, 'area').show()
+        _ = plotting.with_plotly(data, 'area')
 
         data = self.get_sample_data(
             nr_of_columns=10, nr_of_periods=5, time_steps_per_period=24, drop_fraction_of_indices=0.3
         )
-        plotting.with_plotly(data, 'area').show()
+        _ = plotting.with_plotly(data, 'area')
 
     def test_heat_map_plots(self):
         # Generate single-column data with datetime index for heatmap
@@ -101,7 +113,7 @@ class TestPlots(unittest.TestCase):
         # Convert data for heatmap plotting using 'day' as period and 'hour' steps
         heatmap_data = plotting.reshape_to_2d(data.iloc[:, 0].values.flatten(), 24)
         # Plotting heatmaps with Plotly and Matplotlib
-        plotting.heat_map_plotly(pd.DataFrame(heatmap_data)).show()
+        _ = plotting.heat_map_plotly(pd.DataFrame(heatmap_data))
         plotting.heat_map_matplotlib(pd.DataFrame(heatmap_data))
         plt.savefig(f'test_plot_{self._testMethodName}.png', bbox_inches='tight')
         plt.close('all')  # Close all figures to prevent memory leaks
@@ -124,21 +136,21 @@ class TestPlots(unittest.TestCase):
         data = df_irregular
         # Convert data for heatmap plotting using 'day' as period and 'hour' steps
         heatmap_data = plotting.heat_map_data_from_df(data, 'MS', 'D')
-        plotting.heat_map_plotly(heatmap_data).show()
+        _ = plotting.heat_map_plotly(heatmap_data)
         plotting.heat_map_matplotlib(pd.DataFrame(heatmap_data))
         plt.savefig(f'test_plot_{self._testMethodName}.png', bbox_inches='tight')
         plt.close('all')  # Close all figures to prevent memory leaks
 
         heatmap_data = plotting.heat_map_data_from_df(data, 'W', 'h', fill='ffill')
         # Plotting heatmaps with Plotly and Matplotlib
-        plotting.heat_map_plotly(pd.DataFrame(heatmap_data)).show()
+        _ = plotting.heat_map_plotly(pd.DataFrame(heatmap_data))
         plotting.heat_map_matplotlib(pd.DataFrame(heatmap_data))
         plt.savefig(f'test_plot_{self._testMethodName}.png', bbox_inches='tight')
         plt.close('all')  # Close all figures to prevent memory leaks
 
         heatmap_data = plotting.heat_map_data_from_df(data, 'D', 'h', fill='ffill')
         # Plotting heatmaps with Plotly and Matplotlib
-        plotting.heat_map_plotly(pd.DataFrame(heatmap_data)).show()
+        _ = plotting.heat_map_plotly(pd.DataFrame(heatmap_data))
         plotting.heat_map_matplotlib(pd.DataFrame(heatmap_data))
         plt.savefig(f'test_plot_{self._testMethodName}.png', bbox_inches='tight')
         plt.close('all')  # Close all figures to prevent memory leaks

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -130,11 +130,11 @@ def flow_system_complex_scenarios() -> fx.FlowSystem:
         fx.Bus('Strom'),
         fx.Bus('Fernwärme'),
         fx.Bus('Gas'),
-        fx.Sink('Wärmelast', sink=fx.Flow('Q_th_Last', 'Fernwärme', size=1, fixed_relative_profile=thermal_load)),
+        fx.Sink('Wärmelast', inputs=[fx.Flow('Q_th_Last', 'Fernwärme', size=1, fixed_relative_profile=thermal_load)]),
         fx.Source(
-            'Gastarif', source=fx.Flow('Q_Gas', 'Gas', size=1000, effects_per_flow_hour={'costs': 0.04, 'CO2': 0.3})
+            'Gastarif', outputs=[fx.Flow('Q_Gas', 'Gas', size=1000, effects_per_flow_hour={'costs': 0.04, 'CO2': 0.3})]
         ),
-        fx.Sink('Einspeisung', sink=fx.Flow('P_el', 'Strom', effects_per_flow_hour=-1 * electrical_load)),
+        fx.Sink('Einspeisung', inputs=[fx.Flow('P_el', 'Strom', effects_per_flow_hour=-1 * electrical_load)]),
     )
 
     boiler = fx.linear_converters.Boiler(

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -56,7 +56,7 @@ def test_system():
 
     # Create a demand sink with scenario-dependent profiles
     demand = Flow(label='Demand', bus=electricity_bus.label_full, fixed_relative_profile=demand_profiles)
-    demand_sink = Sink('Demand', sink=demand)
+    demand_sink = Sink('Demand', inputs=[demand])
 
     # Create a power source with investment option
     power_gen = Flow(
@@ -69,7 +69,7 @@ def test_system():
         ),
         effects_per_flow_hour={'costs': 20},  # €/MWh
     )
-    generator = Source('Generator', source=power_gen)
+    generator = Source('Generator', outputs=[power_gen])
 
     # Create a storage for electricity
     storage_charge = Flow(label='Charge', bus=electricity_bus.label_full, size=10)


### PR DESCRIPTION
## Description
Remove all warnings from tests AND from user code

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Code refactoring

## Related Issues
Closes #(issue number)

## Testing
- [ ] I have tested my changes
- [ ] Existing tests still pass

## Checklist
- [x] My code follows the project style
- [x] I have updated documentation if needed
- [x] I have added tests for new functionality (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Breaking API: Sinks now use inputs=[Flow(...)] instead of sink=..., Sources use outputs=[Flow(...)] instead of source=....
  - Renamed CO2 parameter maximum_operation_per_hour to maximum_per_hour.
- Bug Fixes
  - More reliable figure export/display; prevents lingering sockets and ensures figures are closed after save/show.
  - Results assembly more robust when components have mismatched dimensions (outer join).
- Chores
  - Reduced warning noise by filtering selected third‑party warnings; pytest warning policies added.
- Tests
  - Non‑interactive plotting and automatic figure cleanup to improve test stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->