### PR TITLE
Change to save netcdf files with 'h5netcdf' instead of netcdf4

### DIFF
--- a/flixopt/calculation.py
+++ b/flixopt/calculation.py
@@ -164,7 +164,7 @@ class FullCalculation(Calculation):
             from .io import document_linopy_model
 
             document_linopy_model(self.model, paths.model_documentation)
-            self.flow_system.to_netcdf(paths.flow_system)
+            self.flow_system.to_netcdf(paths.flow_system, engine='h5netcdf')
             raise RuntimeError(
                 f'Model was infeasible. Please check {paths.model_documentation=} and {paths.flow_system=} for more information.'
             )

--- a/flixopt/flow_system.py
+++ b/flixopt/flow_system.py
@@ -211,7 +211,13 @@ class FlowSystem:
         ds.attrs = self.as_dict(data_mode='name')
         return ds
 
-    def to_netcdf(self, path: str | pathlib.Path, compression: int = 0, constants_in_dataset: bool = True):
+    def to_netcdf(
+        self,
+        path: str | pathlib.Path,
+        compression: int = 0,
+        constants_in_dataset: bool = True,
+        engine: str = 'h5netcdf',
+    ):
         """
         Saves the FlowSystem to a netCDF file.
         Args:
@@ -220,7 +226,7 @@ class FlowSystem:
             constants_in_dataset: If True, constants are included as Dataset variables.
         """
         ds = self.as_dataset(constants_in_dataset=constants_in_dataset)
-        fx_io.save_dataset_to_netcdf(ds, path, compression=compression)
+        fx_io.save_dataset_to_netcdf(ds, path, compression=compression, engine='h5netcdf')
         logger.info(f'Saved FlowSystem to {path}')
 
     def plot_network(

--- a/flixopt/io.py
+++ b/flixopt/io.py
@@ -208,6 +208,7 @@ def save_dataset_to_netcdf(
     ds: xr.Dataset,
     path: str | pathlib.Path,
     compression: int = 0,
+    engine: str = 'h5netcdf',
 ) -> None:
     """
     Save a dataset to a netcdf file. Store the attrs as a json string in the 'attrs' attribute.
@@ -240,6 +241,7 @@ def save_dataset_to_netcdf(
         encoding=None
         if not apply_encoding
         else {data_var: {'zlib': True, 'complevel': compression} for data_var in ds.data_vars},
+        engine='h5netcdf',
     )
 
 

--- a/flixopt/results.py
+++ b/flixopt/results.py
@@ -328,8 +328,8 @@ class CalculationResults:
 
         paths = fx_io.CalculationResultsPaths(folder, name)
 
-        fx_io.save_dataset_to_netcdf(self.solution, paths.solution, compression=compression)
-        fx_io.save_dataset_to_netcdf(self.flow_system, paths.flow_system, compression=compression)
+        fx_io.save_dataset_to_netcdf(self.solution, paths.solution, compression=compression, engine='h5netcdf')
+        fx_io.save_dataset_to_netcdf(self.flow_system, paths.flow_system, compression=compression, engine='h5netcdf')
 
         with open(paths.summary, 'w', encoding='utf-8') as f:
             yaml.dump(self.summary, f, allow_unicode=True, sort_keys=False, indent=4, width=1000)
@@ -338,7 +338,7 @@ class CalculationResults:
             if self.model is None:
                 logger.critical('No model in the CalculationResults. Saving the model is not possible.')
             else:
-                self.model.to_netcdf(paths.linopy_model)
+                self.model.to_netcdf(paths.linopy_model, engine='h5netcdf')
 
         if document_model:
             if self.model is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "xarray >= 2024.2.0, < 2026.0",  # CalVer: allow through next calendar year
     # Optimization and data handling
     "linopy >= 0.5.1, < 0.6",  # Widened from patch pin to minor range
-    "netcdf4 >= 1.6.1, < 2",
+    "h5netcdf>=1.0.0, < 2",
     # Utilities
     "pyyaml >= 6.0.0, < 7",
     "rich >= 13.0.0, < 15",


### PR DESCRIPTION
## Description
Change to save netcdf files with 'h5netcdf' instead of netcdf4. Following xarray default

- Updated `save_dataset_to_netcdf` and related methods to accept the `engine` parameter.
- Changed default netCDF engine to `h5netcdf` across the codebase.
- Updated dependencies to include `h5netcdf`.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Code refactoring

## Related Issues
Closes #(issue number)

## Testing
- [ ] I have tested my changes
- [ ] Existing tests still pass

## Checklist
- [x] My code follows the project style
- [x] I have updated documentation if needed
- [x] I have added tests for new functionality (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added ability to choose the NetCDF engine when exporting results and flow systems (defaults to h5netcdf).
- Bug Fixes
  - When optimization is infeasible, the flow system is now saved to NetCDF before the error is raised, improving debuggability.
- Chores
  - Updated dependency to use h5netcdf instead of netcdf4 for NetCDF writing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->