### PR TITLE
Add error handling for empty buses

### DIFF
--- a/flixopt/elements.py
+++ b/flixopt/elements.py
@@ -207,6 +207,10 @@ class Bus(Element):
                 logger.warning(
                     f'In Bus {self.label_full}, the excess_penalty_per_flow_hour is 0. Use "None" or a value > 0.'
                 )
+        if len(self.inputs) == 0 and len(self.outputs) == 0:
+            raise ValueError(
+                f'Bus "{self.label_full}" has no Flows connected to it. Please remove it from the FlowSystem'
+            )
 
     @property
     def with_excess(self) -> bool:


### PR DESCRIPTION
## Description
Add proper error message when having no Flows connected to a bus

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring

## Related Issues
Closes #287 

## Testing
- [ ] I have tested my changes
- [ ] Existing tests still pass

## Checklist
- [x] My code follows the project style
- [x] I have updated documentation if needed
- [x] I have added tests for new functionality (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced bus validation. The system now raises a clear error message when a bus has no connected flows, helping users identify and remove unconnected buses from the flow system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->