### PR TITLE
ci: run only fast tests and skip slow notebooks on draft PRs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -91,6 +91,14 @@ jobs:
             grep -vFf slow_notebooks.txt | \
             xargs -P 4 -I {} sh -c 'jupyter execute --inplace "$1" || exit 255' _ {}
 
+      - name: Execute slow notebooks
+        if: steps.notebook-cache.outputs.cache-hit != 'true' && github.event.pull_request.draft != true
+        run: |
+          set -eo pipefail
+          # Execute slow notebooks (skip on draft PRs)
+          cd docs/notebooks && cat slow_notebooks.txt | \
+            xargs -I {} sh -c 'jupyter execute --inplace "$1" || exit 255' _ {}
+
       - name: Build docs
         env:
           MKDOCS_JUPYTER_EXECUTE: "false"

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -7,11 +7,13 @@ on:
       - 'docs/**'
       - 'mkdocs.yml'
       - 'flixopt/**'
+      - '.github/workflows/**'
   pull_request:
     paths:
       - 'docs/**'
       - 'mkdocs.yml'
       - 'flixopt/**'  # notebooks import flixopt; catch library changes that break docs
+      - '.github/workflows/**'
   workflow_dispatch:
     inputs:
       deploy:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -9,6 +9,7 @@ on:
       - 'flixopt/**'
       - '.github/workflows/**'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'docs/**'
       - 'mkdocs.yml'
@@ -94,12 +95,12 @@ jobs:
             xargs -P 4 -I {} sh -c 'jupyter execute --inplace "$1" || exit 255' _ {}
 
       - name: Execute slow notebooks
-        if: steps.notebook-cache.outputs.cache-hit != 'true' && github.event.pull_request.draft != true
+        if: steps.notebook-cache.outputs.cache-hit != 'true' && github.event.pull_request.draft != 'true'
         run: |
           set -eo pipefail
-          # Execute slow notebooks (skip on draft PRs)
+          # Execute slow notebooks in parallel (skip on draft PRs)
           cd docs/notebooks && cat slow_notebooks.txt | \
-            xargs -I {} sh -c 'jupyter execute --inplace "$1" || exit 255' _ {}
+            xargs -P 4 -I {} sh -c 'jupyter execute --inplace "$1" || exit 255' _ {}
 
       - name: Build docs
         env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,6 +9,7 @@ on:
       - 'pyproject.toml'
       - '.github/workflows/**'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: ["**"]
     paths:
       - 'flixopt/**'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -63,7 +63,7 @@ jobs:
       - name: Run tests
         run: |
           if [[ "${{ github.event.pull_request.draft }}" == "true" ]]; then
-            pytest -v --numprocesses=auto -m "not slow"
+            pytest -v --numprocesses=auto -m "not slow and not deprecated_api"
           else
             pytest -v --numprocesses=auto
           fi

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -61,7 +61,12 @@ jobs:
         run: uv pip install --system .[dev]
 
       - name: Run tests
-        run: pytest -v --numprocesses=auto
+        run: |
+          if [[ "${{ github.event.pull_request.draft }}" == "true" ]]; then
+            pytest -v --numprocesses=auto -m "not slow"
+          else
+            pytest -v --numprocesses=auto
+          fi
 
   test-examples:
     runs-on: ubuntu-24.04

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -63,8 +63,10 @@ jobs:
       - name: Run tests
         run: |
           if [[ "${{ github.event.pull_request.draft }}" == "true" ]]; then
-            pytest -v --numprocesses=auto -m "not slow and not deprecated_api"
+            # Draft PR: skip examples, slow, and deprecated_api
+            pytest -v --numprocesses=auto -m "not examples and not slow and not deprecated_api"
           else
+            # Ready PR & main push: examples excluded via addopts
             pytest -v --numprocesses=auto
           fi
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,12 +7,14 @@ on:
       - 'flixopt/**'
       - 'tests/**'
       - 'pyproject.toml'
+      - '.github/workflows/**'
   pull_request:
     branches: ["**"]
     paths:
       - 'flixopt/**'
       - 'tests/**'
       - 'pyproject.toml'
+      - '.github/workflows/**'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,8 +3,16 @@ name: Tests
 on:
   push:
     branches: [main]
+    paths:
+      - 'flixopt/**'
+      - 'tests/**'
+      - 'pyproject.toml'
   pull_request:
     branches: ["**"]
+    paths:
+      - 'flixopt/**'
+      - 'tests/**'
+      - 'pyproject.toml'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Description
Brief description of the changes in this PR.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring

## Related Issues
Closes #(issue number)

## Testing
- [ ] I have tested my changes
- [ ] Existing tests still pass

## Checklist
- [x] My code follows the project style
- [x] I have updated documentation if needed
- [x] I have added tests for new functionality (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded CI workflow triggers and added path-based filters for documentation and test runs.
  * Documentation builds now run slow notebooks in parallel when the executed-notebooks cache is missing, skipping this step for draft pull requests.
* **Tests**
  * Test execution is draft-aware: draft pull requests exclude non-essential test categories, while non-draft/ready builds run the full suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->