### PR TITLE
fix: suppress tsam 3.3.0 ClusterConfig.weights deprecation

### DIFF
--- a/flixopt/transform_accessor.py
+++ b/flixopt/transform_accessor.py
@@ -1780,9 +1780,14 @@ class TransformAccessor:
                 if selector:
                     logger.info(f'Clustering {", ".join(f"{k}={v}" for k, v in selector.items())}...')
 
-                # Suppress tsam warning about minimal value constraints (informational, not actionable)
+                # Suppress tsam warnings:
+                # - minimal value constraints (informational, not actionable)
+                # - ClusterConfig.weights deprecation (will be addressed in clustering refactor)
                 with warnings.catch_warnings():
                     warnings.filterwarnings('ignore', category=UserWarning, message='.*minimal value.*exceeds.*')
+                    warnings.filterwarnings(
+                        'ignore', category=DeprecationWarning, message='.*Passing weights via ClusterConfig.*'
+                    )
 
                     # Build ClusterConfig with auto-calculated weights, filtered to available columns
                     clustering_weights = self._calculate_clustering_weights(ds_slice)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ network_viz = [
 
 # Full feature set (everything except dev tools)
 full = [
-    "tsam >= 3.1.2, < 4",  # Time series aggregation for clustering (3.0.0 and 3.1.0 yanked)
+    "tsam >= 3.3.0, < 4",  # Time series aggregation for clustering (3.0.0 and 3.1.0 yanked)
     "pyvis==0.3.2",  # Visualizing FlowSystem Network
     "scipy >= 1.15.1, < 2", # Used by tsam. Prior versions have conflict with highspy. See https://github.com/scipy/scipy/issues/22257
     "gurobipy >= 10.0.0, < 14; python_version < '3.14'",  # No Python 3.14 wheels yet (expected Q1 2026)


### PR DESCRIPTION
## Summary
- Suppress `DeprecationWarning` from tsam 3.3.0 when passing `weights` via `ClusterConfig` — this broke doc deployment CI ([run](https://github.com/flixOpt/flixopt/actions/runs/23732863890/job/69130413876))
- Bump tsam minimum from `>= 3.1.2` to `>= 3.3.0` to match pinned version
- Temporary fix until #654 migrates to the new top-level `weights` API

## Test plan
- [x] `python -W error::DeprecationWarning` clustering call completes without error
- [x] All clustering tests pass (244 passed, 4 pre-existing failures unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated tsam dependency minimum version requirement to 3.3.0 for the full installation profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->