### PR TITLE
fix: explicit adjacent-timestep alignment for linopy v1 compat

### DIFF
--- a/flixopt/components.py
+++ b/flixopt/components.py
@@ -974,7 +974,7 @@ class StorageModel(ComponentModel):
         """For 'cyclic' cluster mode: each cluster's start equals its end."""
         if self._model.flow_system.clusters is not None and self.element.cluster_mode == 'cyclic':
             self.add_constraints(
-                self.charge_state.isel(time=0) == self.charge_state.isel(time=-2),
+                self.charge_state.isel(time=0, drop=True) == self.charge_state.isel(time=-2, drop=True),
                 short_name='cluster_cyclic',
             )
 
@@ -1018,24 +1018,24 @@ class StorageModel(ComponentModel):
         if self.element.initial_charge_state is not None:
             if isinstance(self.element.initial_charge_state, str):
                 self.add_constraints(
-                    self.charge_state.isel(time=0) == self.charge_state.isel(time=-1),
+                    self.charge_state.isel(time=0, drop=True) == self.charge_state.isel(time=-1, drop=True),
                     short_name='initial_charge_state',
                 )
             else:
                 self.add_constraints(
-                    self.charge_state.isel(time=0) == self.element.initial_charge_state,
+                    self.charge_state.isel(time=0, drop=True) == self.element.initial_charge_state,
                     short_name='initial_charge_state',
                 )
 
         if self.element.maximal_final_charge_state is not None:
             self.add_constraints(
-                self.charge_state.isel(time=-1) <= self.element.maximal_final_charge_state,
+                self.charge_state.isel(time=-1, drop=True) <= self.element.maximal_final_charge_state,
                 short_name='final_charge_max',
             )
 
         if self.element.minimal_final_charge_state is not None:
             self.add_constraints(
-                self.charge_state.isel(time=-1) >= self.element.minimal_final_charge_state,
+                self.charge_state.isel(time=-1, drop=True) >= self.element.minimal_final_charge_state,
                 short_name='final_charge_min',
             )
 
@@ -1072,9 +1072,13 @@ class StorageModel(ComponentModel):
         eff_charge = self.element.eta_charge
         eff_discharge = self.element.eta_discharge
 
+        # charge_state lives on timesteps_extra; index the balance on the regular timesteps
+        # (the start of each interval) so it aligns with charge_rate / discharge_rate.
+        charge_state_t = charge_state.isel(time=slice(None, -1))
+        charge_state_tp1 = charge_state.isel(time=slice(1, None)).assign_coords(time=charge_state_t.coords['time'])
         return (
-            charge_state.isel(time=slice(1, None))
-            - charge_state.isel(time=slice(None, -1)) * ((1 - rel_loss) ** timestep_duration)
+            charge_state_tp1
+            - charge_state_t * ((1 - rel_loss) ** timestep_duration)
             - charge_rate * eff_charge * timestep_duration
             + discharge_rate * timestep_duration / eff_discharge
         )

--- a/flixopt/features.py
+++ b/flixopt/features.py
@@ -91,8 +91,10 @@ class InvestmentModel(Submodel):
 
         if self.parameters.linked_periods is not None:
             masked_size = self.size.where(self.parameters.linked_periods, drop=True)
+            lead_period = masked_size.coords['period'].isel(period=slice(1, None))
             self.add_constraints(
-                masked_size.isel(period=slice(None, -1)) == masked_size.isel(period=slice(1, None)),
+                masked_size.isel(period=slice(None, -1)).assign_coords(period=lead_period)
+                == masked_size.isel(period=slice(1, None)),
                 short_name='linked_periods',
             )
 
@@ -295,7 +297,7 @@ class StatusModel(Submodel):
         """For 'cyclic' cluster mode: each cluster's start status equals its end status."""
         if self._model.flow_system.clusters is not None and self.parameters.cluster_mode == 'cyclic':
             self.add_constraints(
-                self.status.isel(time=0) == self.status.isel(time=-1),
+                self.status.isel(time=0, drop=True) == self.status.isel(time=-1, drop=True),
                 short_name='cluster_cyclic',
             )
 

--- a/flixopt/modeling.py
+++ b/flixopt/modeling.py
@@ -403,19 +403,27 @@ class ModelingPrimitives:
         # Upper bound: duration[t] ≤ state[t] * M
         constraints['ub'] = model.add_constraints(duration <= state * mega, name=f'{duration.name}|ub')
 
+        # Adjacent-step constraints are indexed by lag (start-of-interval) labels; lead operands
+        # are relabeled onto the lag axis so positional alignment is explicit (linopy v1 requires
+        # matching labels on shared dims). The lag convention also preserves the lb semantics —
+        # duration[t] there must reference the on-state moment, not the off-transition that follows.
+        lag = {duration_dim: slice(None, -1)}
+        lead = {duration_dim: slice(1, None)}
+        lag_coord = {duration_dim: duration.coords[duration_dim].isel(lag)}
+
         # Forward constraint: duration[t+1] ≤ duration[t] + duration_per_step[t]
         constraints['forward'] = model.add_constraints(
-            duration.isel({duration_dim: slice(1, None)})
-            <= duration.isel({duration_dim: slice(None, -1)}) + duration_per_step.isel({duration_dim: slice(None, -1)}),
+            duration.isel(lead).assign_coords(lag_coord)
+            <= duration.isel(lag) + duration_per_step.isel(lag),
             name=f'{duration.name}|forward',
         )
 
         # Backward constraint: duration[t+1] ≥ duration[t] + duration_per_step[t] + (state[t+1] - 1) * M
         constraints['backward'] = model.add_constraints(
-            duration.isel({duration_dim: slice(1, None)})
-            >= duration.isel({duration_dim: slice(None, -1)})
-            + duration_per_step.isel({duration_dim: slice(None, -1)})
-            + (state.isel({duration_dim: slice(1, None)}) - 1) * mega,
+            duration.isel(lead).assign_coords(lag_coord)
+            >= duration.isel(lag)
+            + duration_per_step.isel(lag)
+            + (state.isel(lead).assign_coords(lag_coord) - 1) * mega,
             name=f'{duration.name}|backward',
         )
 
@@ -423,17 +431,18 @@ class ModelingPrimitives:
         # Skipped if previous_duration is None (unconstrained initial state)
         if previous_duration is not None:
             constraints['initial'] = model.add_constraints(
-                duration.isel({duration_dim: 0})
-                == (duration_per_step.isel({duration_dim: 0}) + previous_duration) * state.isel({duration_dim: 0}),
+                duration.isel({duration_dim: 0}, drop=True)
+                == (duration_per_step.isel({duration_dim: 0}, drop=True) + previous_duration)
+                * state.isel({duration_dim: 0}, drop=True),
                 name=f'{duration.name}|initial',
             )
 
         # Minimum duration constraint if provided
         if minimum_duration is not None:
             constraints['lb'] = model.add_constraints(
-                duration
-                >= (state.isel({duration_dim: slice(None, -1)}) - state.isel({duration_dim: slice(1, None)}))
-                * _scalar_safe_isel(minimum_duration, {duration_dim: slice(None, -1)}),
+                duration.isel(lag)
+                >= (state.isel(lag) - state.isel(lead).assign_coords(lag_coord))
+                * _scalar_safe_isel(minimum_duration, lag),
                 name=f'{duration.name}|lb',
             )
 
@@ -447,7 +456,7 @@ class ModelingPrimitives:
                 min0 = float(_scalar_safe_isel(minimum_duration, {duration_dim: 0}).max().item())
                 if prev > 0 and prev < min0:
                     constraints['initial_lb'] = model.add_constraints(
-                        state.isel({duration_dim: 0}) == 1, name=f'{duration.name}|initial_lb'
+                        state.isel({duration_dim: 0}, drop=True) == 1, name=f'{duration.name}|initial_lb'
                     )
 
         variables = {'duration': duration}
@@ -712,17 +721,22 @@ class BoundingPatterns:
         if not isinstance(model, Submodel):
             raise ValueError('BoundingPatterns.state_transition_bounds() can only be used with a Submodel')
 
-        # State transition constraints for t > 0
+        # State transition constraints for t > 0; relabel the lag slice onto the lead axis so
+        # positional alignment is explicit (linopy v1 requires matching labels on shared dims).
+        lead = {coord: slice(1, None)}
+        lag = {coord: slice(None, -1)}
+        lead_coord = {coord: state.coords[coord].isel(lead)}
         transition = model.add_constraints(
-            activate.isel({coord: slice(1, None)}) - deactivate.isel({coord: slice(1, None)})
-            == state.isel({coord: slice(1, None)}) - state.isel({coord: slice(None, -1)}),
+            activate.isel(lead) - deactivate.isel(lead)
+            == state.isel(lead) - state.isel(lag).assign_coords(lead_coord),
             name=f'{name}|transition',
         )
 
         # Initial state transition for t = 0 (skipped if previous_state is None for unconstrained)
         if previous_state is not None:
             initial = model.add_constraints(
-                activate.isel({coord: 0}) - deactivate.isel({coord: 0}) == state.isel({coord: 0}) - previous_state,
+                activate.isel({coord: 0}, drop=True) - deactivate.isel({coord: 0}, drop=True)
+                == state.isel({coord: 0}, drop=True) - previous_state,
                 name=f'{name}|initial',
             )
         else:

--- a/flixopt/modeling.py
+++ b/flixopt/modeling.py
@@ -413,8 +413,7 @@ class ModelingPrimitives:
 
         # Forward constraint: duration[t+1] ≤ duration[t] + duration_per_step[t]
         constraints['forward'] = model.add_constraints(
-            duration.isel(lead).assign_coords(lag_coord)
-            <= duration.isel(lag) + duration_per_step.isel(lag),
+            duration.isel(lead).assign_coords(lag_coord) <= duration.isel(lag) + duration_per_step.isel(lag),
             name=f'{duration.name}|forward',
         )
 
@@ -727,8 +726,7 @@ class BoundingPatterns:
         lag = {coord: slice(None, -1)}
         lead_coord = {coord: state.coords[coord].isel(lead)}
         transition = model.add_constraints(
-            activate.isel(lead) - deactivate.isel(lead)
-            == state.isel(lead) - state.isel(lag).assign_coords(lead_coord),
+            activate.isel(lead) - deactivate.isel(lead) == state.isel(lead) - state.isel(lag).assign_coords(lead_coord),
             name=f'{name}|transition',
         )
 
@@ -788,31 +786,24 @@ class BoundingPatterns:
         if not isinstance(model, Submodel):
             raise ValueError('ModelingPrimitives.continuous_transition_bounds() can only be used with a Submodel')
 
-        # Transition constraints for t > 0: continuous variable can only change when transitions occur
-        transition_upper = model.add_constraints(
-            continuous_variable.isel({coord: slice(1, None)}) - continuous_variable.isel({coord: slice(None, -1)})
-            <= max_change * (activate.isel({coord: slice(1, None)}) + deactivate.isel({coord: slice(1, None)})),
-            name=f'{name}|transition_ub',
-        )
+        # Transition constraints for t > 0: continuous variable can only change when transitions occur.
+        # Lag slices are relabeled onto the lead axis so positional alignment is explicit
+        # (linopy v1 requires matching labels on shared dims).
+        lead = {coord: slice(1, None)}
+        lag = {coord: slice(None, -1)}
+        lead_coord = {coord: continuous_variable.coords[coord].isel(lead)}
+        change = continuous_variable.isel(lead) - continuous_variable.isel(lag).assign_coords(lead_coord)
+        transition_bound = max_change * (activate.isel(lead) + deactivate.isel(lead))
 
-        transition_lower = model.add_constraints(
-            -(continuous_variable.isel({coord: slice(1, None)}) - continuous_variable.isel({coord: slice(None, -1)}))
-            <= max_change * (activate.isel({coord: slice(1, None)}) + deactivate.isel({coord: slice(1, None)})),
-            name=f'{name}|transition_lb',
-        )
+        transition_upper = model.add_constraints(change <= transition_bound, name=f'{name}|transition_ub')
+        transition_lower = model.add_constraints(-change <= transition_bound, name=f'{name}|transition_lb')
 
         # Initial constraints for t = 0
-        initial_upper = model.add_constraints(
-            continuous_variable.isel({coord: 0}) - previous_value
-            <= max_change * (activate.isel({coord: 0}) + deactivate.isel({coord: 0})),
-            name=f'{name}|initial_ub',
-        )
+        initial_bound = max_change * (activate.isel({coord: 0}, drop=True) + deactivate.isel({coord: 0}, drop=True))
+        initial_change = continuous_variable.isel({coord: 0}, drop=True) - previous_value
 
-        initial_lower = model.add_constraints(
-            -continuous_variable.isel({coord: 0}) + previous_value
-            <= max_change * (activate.isel({coord: 0}) + deactivate.isel({coord: 0})),
-            name=f'{name}|initial_lb',
-        )
+        initial_upper = model.add_constraints(initial_change <= initial_bound, name=f'{name}|initial_ub')
+        initial_lower = model.add_constraints(-initial_change <= initial_bound, name=f'{name}|initial_lb')
 
         return transition_upper, transition_lower, initial_upper, initial_lower
 
@@ -859,17 +850,22 @@ class BoundingPatterns:
 
         # 1. Initial period: level[0] - initial_level =  increase[0] - decrease[0]
         initial_constraint = model.add_constraints(
-            level_variable.isel({coord: 0}) - initial_level
-            == increase_variable.isel({coord: 0}) - decrease_variable.isel({coord: 0}),
+            level_variable.isel({coord: 0}, drop=True) - initial_level
+            == increase_variable.isel({coord: 0}, drop=True) - decrease_variable.isel({coord: 0}, drop=True),
             name=f'{name}|initial_level',
         )
 
-        # 2. Transition periods: level[t] = level[t-1] + increase[t] - decrease[t] for t > 0
+        # 2. Transition periods: level[t] = level[t-1] + increase[t] - decrease[t] for t > 0.
+        # Lag slice of level_variable is relabeled onto the lead axis so positional alignment is
+        # explicit (linopy v1 requires matching labels on shared dims).
+        lead = {coord: slice(1, None)}
+        lag = {coord: slice(None, -1)}
+        lead_coord = {coord: level_variable.coords[coord].isel(lead)}
         transition_constraints = model.add_constraints(
-            level_variable.isel({coord: slice(1, None)})
-            == level_variable.isel({coord: slice(None, -1)})
-            + increase_variable.isel({coord: slice(1, None)})
-            - decrease_variable.isel({coord: slice(1, None)}),
+            level_variable.isel(lead)
+            == level_variable.isel(lag).assign_coords(lead_coord)
+            + increase_variable.isel(lead)
+            - decrease_variable.isel(lead),
             name=f'{name}|transitions',
         )
 


### PR DESCRIPTION
## Summary
- Relabel adjacent-step slices with `.assign_coords(...)` at the handful of sites where flixopt combines `[1:]` and `[:-1]` of the same variable to build difference/transition constraints. Under linopy's legacy semantics these aligned silently by position; the upcoming v1 convention ([PyPSA/linopy#717](https://github.com/PyPSA/linopy/pull/717)) requires shared-dim labels to match exactly.
- Pass `drop=True` to scalar `.isel(time=0)` / `.isel(time=-1)` patterns so leftover aux coords don't conflict on combination.
- In `consecutive_duration_tracking`, switch to a lag-label convention throughout so the `lb` constraint references duration at the on-state moment (the off-transition timestep has `duration=0`).

## Sites
- `flixopt/components.py:_build_energy_balance_lhs` — storage energy balance.
- `flixopt/components.py:_add_cluster_cyclic_constraint`, `_add_initial_final_constraints` — scalar `.isel` calls.
- `flixopt/modeling.py:ModelingPrimitives.consecutive_duration_tracking` — forward / backward / initial / lb.
- `flixopt/modeling.py:BoundingPatterns.state_transition_bounds` — transition + initial.
- `flixopt/features.py:InvestmentModel` linked-periods constraint.
- `flixopt/features.py:StatusModel._add_cluster_cyclic_constraint`.

## Validation
With `linopy.options.set_value(semantics='v1')`:
- `tests/test_math/`: **383 pass / 3 fail** (was 236/150). The 3 remaining failures are pre-existing on `main` (`TestClusteringExact::test_storage_cyclic_charge_discharge_pattern`), unrelated to this change.
- Broader `tests/` (excluding `test_math/`): no v1-specific regressions — same 68 pre-existing failures under both legacy and v1.

## Test plan
- [ ] `pytest tests/test_math/` passes under legacy semantics (no behavior change).
- [ ] `pytest tests/test_math/` passes under v1 (`linopy.options.set_value(semantics='v1')`) with only the 3 pre-existing failures.
- [ ] Solve a representative model with both modes and confirm equal objective and SOC trajectories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed constraint construction and time-coordinate alignment for cyclic operation and energy-balance calculations to ensure consistent behavior at period boundaries.
  * Resolved incorrect timestep handling in state-transition and duration-tracking constraints so constraints align correctly across consecutive timesteps.

* **Refactor**
  * Reworked constraint slicing and coordinate-assignment logic for clearer, more robust timestep alignment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flixOpt/flixopt/pull/684?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->