### PR TITLE
fix: exclude highspy 1.14.0 (closes #685)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,9 @@ dependencies = [
     "colorlog >= 6.8.0, < 7",
     "tqdm >= 4.66.0, < 5",
     # Default solver
-    "highspy >= 1.5.3, < 2",
+    # 1.14.0 excluded: presolve regression returns wrong MIP optima on big-M / invest-style models.
+    # Fixed on HiGHS `latest` branch but not yet released. See ERGO-Code/HiGHS#2975 and PyPSA/linopy#651.
+    "highspy >= 1.5.3, < 2, != 1.14.0",
     # Visualization
     "matplotlib >= 3.5.2, < 4",
     "plotly >= 5.15.0, < 7",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ dev = [
     "pre-commit==4.6.0",
     "pyvis==0.3.2",
     "scipy==1.16.3",  # 1.16.1+ required for Python 3.14 wheels
+    "highspy==1.13.1",  # Latest known-good. Bump once HiGHS#2975 fix ships in 1.14.1+
     "gurobipy==12.0.3; python_version < '3.14'",  # No Python 3.14 wheels yet
     "dash==3.3.0",
     "dash-cytoscape==1.0.2",


### PR DESCRIPTION
## Summary
- Excludes `highspy==1.14.0` from `pyproject.toml`. 1.14.0 has a presolve regression that returns wrong MIP optima on big-M / invest-style models, off by orders of magnitude on the affected tests.
- Fixed upstream on the HiGHS `latest` branch (commit `e8c0584a`) but **not yet released** — `highspy 1.14.0` is still the only 1.14.x on PyPI.
- linopy [already excludes 1.14.0](https://github.com/PyPSA/linopy/pull/653), but only inside their `solvers` extra, which flixopt does not pull. The constraint therefore never propagated, and CI's `uv pip install --system .[dev]` started picking up 1.14.0 once it became `highspy`'s latest release.

## What was actually failing
Closes #685 — which mis-diagnosed the problem. Reality:
- The 4 CI failures from 2026-04-20 were a `tsam 3.3.0` bug, already fixed by #679 bumping to 3.4.0.
- The remaining failures (9 tests on Python 3.11 only) all came from `highspy==1.14.0`. Same flixopt code on `highspy==1.13.1` or `1.12.0` passes.
- Confirmed by bisecting `highspy` versions across both Python 3.11 and 3.13 venvs with otherwise-identical resolution.
- linopy 0.5.8 / 0.6.6 / 0.7.0 all pass when paired with a non-1.14 highspy.

## Test plan
- [x] Fresh `uv pip install --system .[dev]` on Python 3.11 now resolves `highspy 1.13.1` and all 36 `test_flow_invest.py` tests pass.
- [x] Full suite (`pytest tests/ --numprocesses=auto`) passes on linopy 0.7.0 with the new pin.
- [ ] Drop the `!= 1.14.0` exclusion once `highspy 1.14.1`+ is released.

## Suggested follow-up (not in this PR)
- Issue #685 also notes that dependabot PRs don't trigger `Tests`. That's still true and is what masked the original tsam regression; worth fixing in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency constraints to exclude a specific version with known issues that could affect calculation accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flixOpt/flixopt/pull/686?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->