### PR TITLE
fix: stop using deprecated tsam ClusterConfig(weights=) API

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -11,6 +11,7 @@ on:
     paths:
       - 'docs/**'
       - 'mkdocs.yml'
+      - 'flixopt/**'  # notebooks import flixopt; catch library changes that break docs
   workflow_dispatch:
     inputs:
       deploy:

--- a/docs/notebooks/data/generate_realistic_profiles.py
+++ b/docs/notebooks/data/generate_realistic_profiles.py
@@ -166,8 +166,12 @@ class ElectricityLoadGenerator:
             Electricity demand profile in kW
         """
         slp_type = self.CONSUMER_TYPES[consumer_type]
-        e_slp = bdew.ElecSlp(self.year, holidays=self.holidays)
-        profile = e_slp.get_scaled_power_profiles({slp_type: annual_demand_kwh})
+        # demandlib calls warnings.simplefilter("error") internally, which would otherwise
+        # leak into the global state and turn every later warning (e.g. third-party
+        # DeprecationWarnings) into a hard error. Contain that side effect here.
+        with warnings.catch_warnings():
+            e_slp = bdew.ElecSlp(self.year, holidays=self.holidays)
+            profile = e_slp.get_scaled_power_profiles({slp_type: annual_demand_kwh})
         # Resample to hourly and align with requested timesteps
         profile_hourly = profile[slp_type].resample('h').mean()
         return profile_hourly.reindex(timesteps, method='ffill').values

--- a/flixopt/transform_accessor.py
+++ b/flixopt/transform_accessor.py
@@ -900,8 +900,12 @@ class TransformAccessor:
         cluster: ClusterConfig | None,
         auto_weights: dict[str, float],
         available_columns: set[str] | None = None,
-    ) -> ClusterConfig:
-        """Merge auto-calculated weights into ClusterConfig.
+    ) -> tuple[ClusterConfig, dict[str, float]]:
+        """Resolve clustering weights and build a ClusterConfig without weights.
+
+        Weights are returned separately so they can be passed as a top-level
+        argument to ``tsam.aggregate``. Passing weights via ``ClusterConfig`` is
+        deprecated in tsam (>= 3.4.0) and raises a ``DeprecationWarning``.
 
         Args:
             cluster: Optional user-provided ClusterConfig.
@@ -912,7 +916,7 @@ class TransformAccessor:
                 (e.g., constant arrays removed before clustering).
 
         Returns:
-            ClusterConfig with weights set (either user-provided or auto-calculated).
+            Tuple of (ClusterConfig without weights, resolved weights dict).
         """
         from tsam import ClusterConfig
 
@@ -926,19 +930,21 @@ class TransformAccessor:
         if available_columns is not None:
             weights = {name: w for name, w in weights.items() if name in available_columns}
 
-        # No ClusterConfig provided - use defaults with weights
+        # No ClusterConfig provided - use defaults (weights passed to aggregate())
         if cluster is None:
-            return ClusterConfig(weights=weights)
+            return ClusterConfig(), weights
 
-        # ClusterConfig provided - use its settings with (possibly filtered) weights
-        return ClusterConfig(
-            method=cluster.method,
-            representation=cluster.representation,
-            weights=weights,
-            normalize_column_means=cluster.normalize_column_means,
-            use_duration_curves=cluster.use_duration_curves,
-            include_period_sums=cluster.include_period_sums,
-            solver=cluster.solver,
+        # ClusterConfig provided - preserve its settings; weights passed to aggregate()
+        return (
+            ClusterConfig(
+                method=cluster.method,
+                representation=cluster.representation,
+                normalize_column_means=cluster.normalize_column_means,
+                use_duration_curves=cluster.use_duration_curves,
+                include_period_sums=cluster.include_period_sums,
+                solver=cluster.solver,
+            ),
+            weights,
         )
 
     def sel(
@@ -1786,7 +1792,7 @@ class TransformAccessor:
 
                     # Build ClusterConfig with auto-calculated weights, filtered to available columns
                     clustering_weights = self._calculate_clustering_weights(ds_slice)
-                    cluster_config = self._build_cluster_config_with_weights(
+                    cluster_config, resolved_weights = self._build_cluster_config_with_weights(
                         cluster, clustering_weights, available_columns=set(df_for_clustering.columns)
                     )
 
@@ -1797,6 +1803,7 @@ class TransformAccessor:
                         period_duration=hours_per_cluster,
                         temporal_resolution=dt,
                         cluster=cluster_config,
+                        weights=resolved_weights,
                         extremes=extremes,
                         segments=segments,
                         preserve_column_means=preserve_column_means,


### PR DESCRIPTION
## Why docs stopped publishing

The docs site (`mike` → `gh-pages`) is pinned at **6.1.0** — releases **6.1.1, 6.1.2, 6.1.3 never deployed**. The `deploy` job in `docs.yaml` has `needs: build`, and the `build` job has been failing at *Execute fast notebooks* since ~6.1.0.

Root cause chain (reproduced locally):
1. The clustering notebooks call `create_district_heating_system()`, which builds load profiles via **`demandlib`**. `demandlib` runs a global `warnings.simplefilter("error")` (`bdew/elec_slp.py`) and never restores it — so every subsequent warning in the kernel becomes a fatal exception.
2. flixopt's clustering then calls **`ClusterConfig(weights=...)`**, which **tsam ≥ 3.4.0 deprecates**.
3. That `DeprecationWarning` → raised → `CellExecutionError` → notebook step fails → `build` fails → `deploy` is skipped.

## Changes

- **`flixopt/transform_accessor.py`** — resolve clustering weights separately and pass them as the top-level `weights=` argument to `tsam.aggregate()` instead of via the deprecated `ClusterConfig(weights=...)`. *(the actual fix)*
- **`docs/notebooks/data/generate_realistic_profiles.py`** — wrap the `demandlib` call in `warnings.catch_warnings()` so its global warnings-as-error side effect can no longer leak and turn unrelated third-party warnings into hard notebook failures.
- **`.github/workflows/docs.yaml`** — add `flixopt/**` to the PR path filter. The notebooks `import flixopt`, but library-only PRs (like the tsam migration that introduced this) previously skipped the docs build, so the breakage only surfaced post-merge.

## Verification

- Clustering runs clean under `-W error::DeprecationWarning` (both default and user-provided `ClusterConfig` paths).
- `08c-clustering.ipynb` executes end-to-end: exit 0, zero cell errors (previously failed).
- Confirmed no `error::Warning` filter leaks into global state after building the example system.
- Full clustering suite green: `pytest tests/test_clustering/` → **250 passed**.

## Note: still-stale versions

`mike`'s `latest` alias is still 6.1.0. After merge, 6.1.1–6.1.3 won't auto-publish — either let the next release deploy them, or manually run the **Docs** workflow via `workflow_dispatch` with `deploy: true`, `version: v6.1.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved warning handling in electricity load profile generation to prevent warning state changes from affecting other warnings throughout the application runtime.

* **Refactoring**
  * Refactored the internal weight resolution mechanism for clustering operations to improve separation of concerns and maintainability.

* **Chores**
  * Updated the documentation workflow configuration to trigger documentation builds when library code changes occur, in addition to documentation file changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flixOpt/flixopt/pull/689?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->