### PR TITLE
fix(docs): remove malicious polyfill.io script reference

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -378,7 +378,6 @@ extra_javascript:
   - javascripts/mathjax.js
   - javascripts/plotly-instant.js
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
 
 watch:
   - flixopt


### PR DESCRIPTION
## Problem

The docs embed `https://polyfill.io/v3/polyfill.min.js?features=es6` (an old MkDocs-Material/MathJax recipe). The polyfill.io domain was sold in 2024 and now serves malware as part of a [supply-chain attack](https://sansec.io/research/polyfill-supply-chain-attack). Visitors to the docs were shown a suspicious login prompt originating from `https://polyfill.io`:

The script only existed to backfill ES6 features for legacy browsers (IE11) and is unnecessary today, so it is removed without replacement.

## Changes

- Remove the `polyfill.io` entry from `extra_javascript` in `mkdocs.yml` → fixes all future doc builds

## Already done out-of-band

The script tag was baked into **4,530 deployed HTML files** across all doc versions (2.0.0–6.1.4) on `gh-pages`. Those were scrubbed directly and pushed in gh-pages commit `a4e2663e` — the live site is already clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an external polyfill dependency from the documentation site configuration. This simplifies the site's dependency management while maintaining support for modern browsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->