### PR TITLE
fix: normalize clustered solution dim order to (cluster, time)

### DIFF
--- a/flixopt/structure.py
+++ b/flixopt/structure.py
@@ -335,6 +335,8 @@ class FlowSystemModel(linopy.Model, SubmodelsMixin):
         if 'time' in solution.coords:
             if not solution.indexes['time'].equals(self.flow_system.timesteps_extra):
                 solution = solution.reindex(time=self.flow_system.timesteps_extra)
+        if 'cluster' in solution.dims and 'time' in solution.dims:
+            solution = solution.transpose('cluster', 'time', ...)
         return solution
 
     @property

--- a/tests/test_math/test_clustering.py
+++ b/tests/test_math/test_clustering.py
@@ -336,12 +336,10 @@ class TestClusteringExact:
         discharge_fr = fs.solution['Battery(discharge)|flow_rate'].values[:, :4]
         assert_allclose(discharge_fr, [[0, 50, 0, 50], [0, 50, 0, 50]], atol=1e-5)
 
-        # Charge state: dims=(time, cluster), 5 entries (incl. final)
-        # Cyclic: SOC wraps, starting with pre-charge from previous cycle
         charge_state = fs.solution['Battery|charge_state']
-        assert charge_state.dims == ('time', 'cluster')
-        cs_c0 = charge_state.values[:5, 0]
-        cs_c1 = charge_state.values[:5, 1]
+        assert charge_state.dims == ('cluster', 'time')
+        cs_c0 = charge_state.isel(cluster=0).values[:5]
+        cs_c1 = charge_state.isel(cluster=1).values[:5]
         assert_allclose(cs_c0, [50, 50, 0, 50, 0], atol=1e-5)
         assert_allclose(cs_c1, [100, 100, 50, 100, 50], atol=1e-5)
 


### PR DESCRIPTION
## What

Makes the public solution layout deterministic for clustered systems:
`charge_state` (and everything else) is always `(cluster, time)`, regardless
of the linopy version. Unblocks the linopy 0.8 bump in #701.

## Root cause

linopy `<0.8` stores the extra-timestep `charge_state` variable as
`(time, cluster)`, while every other variable is `(cluster, time)`. The cause
is internal to linopy 0.7: `charge_state`'s `time` coordinate has length `n+1`
(the extra SOC boundary), which conflicts with the model's `time` (length `n`),
and 0.7 reorders the conflicting dim to the front. I confirmed flixopt **cannot**
fix this from the input side — passing bounds/coords as `(cluster, time)` still
comes back `(time, cluster)` on 0.7.

linopy `0.8.0` ([PyPSA/linopy#732](https://github.com/PyPSA/linopy/pull/732),
*"unify coords-as-truth handling"*) makes the explicit `coords` the source of
truth for dim order, so it's already consistent there.

| linopy | `charge_state.dims` | `flow_rate.dims` |
|--------|---------------------|------------------|
| `<0.8` | `(time, cluster)`   | `(cluster, time)` |
| `>=0.8`| `(cluster, time)`   | `(cluster, time)` |

## Fix

Normalize in `FlowSystemModel.solution`: `transpose('cluster', 'time', ...)`.
- No-op on linopy `>=0.8` and for non-clustered systems.
- Only reorders the cluster/time axes; all other dims and scalars are preserved
  via the ellipsis.

Production code already accesses `charge_state` purely by label, so it was
unaffected either way; this just makes the user-facing solution stable.

The test is updated to access `charge_state` by label and assert the
now-deterministic `(cluster, time)`. The linopy version bump itself stays in #701.

## Verification

- Target test passes on linopy 0.7 (all 3 parametrizations).
- `tests/test_clustering` + `tests/test_math/test_clustering.py` +
  `tests/flow_system/test_flow_system_resample.py`: 288 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)