### PR TITLE
test: de-flake test_heatmap_reshape irregular-data case

### DIFF
--- a/tests/plotting/test_heatmap_reshape.py
+++ b/tests/plotting/test_heatmap_reshape.py
@@ -45,9 +45,12 @@ def test_weekly_daily_pattern(hourly_week_data):
 def test_with_irregular_data():
     """Real-world use case: data with missing timestamps needs filling."""
     time = pd.date_range('2024-01-01', periods=100, freq='15min')
-    data = np.random.rand(100)
-    # Randomly drop 30% to simulate real data gaps
-    keep = np.sort(np.random.choice(100, 70, replace=False))  # Must be sorted
+    # Local generator + retained endpoint: keeps the 25h span deterministic
+    # regardless of test order under pytest-xdist (global np.random state varies).
+    rng = np.random.default_rng(42)
+    data = rng.random(100)
+    # Drop 30% to simulate gaps, but keep the final timestamp so the span stays 25h
+    keep = np.sort(np.append(rng.choice(99, 69, replace=False), 99))
     da = xr.DataArray(data[keep], dims=['time'], coords={'time': time[keep]})
 
     result = reshape_data_for_heatmap(da, reshape_time=('h', 'min'), fill='ffill')


### PR DESCRIPTION
## Problem

`tests/plotting/test_heatmap_reshape.py::test_with_irregular_data` is flaky (~0.7% of runs), failing with `assert 24 == 25`. It surfaced on PR #706's CI but is unrelated to that PR.

## Root cause

The test drops 30% of timestamps using the **module-level `np.random` state**. Under `pytest-xdist`, the global RNG state when this test runs depends on which other tests ran first on the worker — effectively random. When all four timestamps in the final hour (indices 96–99) happen to be dropped, `ffill` stops at hour 23, producing **24** reshaped hours instead of 25, and the hard `== 25` assert fails.

Exact failure probability: `C(96,70)/C(100,70) ≈ 0.70%`. Not a dependency regression — `main` passed June 14 by luck.

## Fix

Use a local `np.random.default_rng(42)` and always retain the final timestamp, so the 25-hour span is deterministic regardless of test order. Verified immune across 500 hostile global-RNG states (always 70 kept, max index 99).

🤖 Generated with [Claude Code](https://claude.com/claude-code)