### PR TITLE
feat(cluster): add cluster_on for true subset clustering

### DIFF
--- a/docs/user-guide/migration-guide-v6.md
+++ b/docs/user-guide/migration-guide-v6.md
@@ -6,6 +6,10 @@
     ```
     v6.0.0 brings tsam v3 integration, faster I/O, and new clustering features. Review this guide to update your code.
 
+!!! info "Upgrading to v7?"
+    v7.0.0 replaces the clustering backend (tsam → tsam_xarray) and changes the
+    `Clustering` API. See the [Migration Guide v7](migration-guide-v7.md).
+
 ---
 
 ## Overview
@@ -143,99 +147,6 @@ The clustering API now uses tsam v3's configuration objects instead of individua
 
 ---
 
-### Clustering Backend: tsam_xarray
-
-v6.0.0 replaces the per-slice tsam loop with a single
-[`tsam_xarray.aggregate()`](https://github.com/FZJ-IEK3-VSA/tsam_xarray) call. The
-`Clustering` object is now a thin wrapper around `tsam_xarray.ClusteringResult` /
-`AggregationResult`. Most code keeps working, but the items below changed.
-
-#### Removed: `data_vars` parameter
-
-Use `ClusterConfig(weights={var: 0})` to exclude variables from cluster assignment
-while still aggregating them.
-
-!!! note "Default weight is 1.0, not 0"
-    Variables omitted from `ClusterConfig(weights={...})` keep the default
-    weight of **1.0** and still influence cluster assignments. To exclude a
-    variable from the clustering objective without dropping it from the
-    aggregated FlowSystem, set its weight explicitly to `0`.
-
-=== "v5.x (Old)"
-    ```python
-    fs_clustered = flow_system.transform.cluster(
-        n_clusters=8,
-        cluster_duration='1D',
-        data_vars=['HeatDemand(Q)|fixed_relative_profile'],  # cluster on this only
-    )
-    ```
-
-=== "v6.0.0 (New)"
-    ```python
-    from tsam import ClusterConfig
-
-    fs_clustered = flow_system.transform.cluster(
-        n_clusters=8,
-        cluster_duration='1D',
-        cluster=ClusterConfig(weights={
-            'HeatDemand(Q)|fixed_relative_profile': 1,
-            'GasSource(Gas)|costs|per_flow_hour': 0,  # ignored for clustering
-        }),
-    )
-    ```
-
-#### Removed: `TimeSeriesData(clustering_group=..., clustering_weight=...)`
-
-Auto-weighting from `clustering_group` / `clustering_weight` attributes has been
-removed. Provide weights explicitly via `ClusterConfig(weights={...})`.
-
-#### Removed: `Clustering.metrics` and `clustering.plot`
-
-`metrics` (RMSE/MAE), `plot.compare()`, `plot.heatmap()`, `plot.clusters()`, and
-`include_original_data=...` on `to_netcdf` / `to_dataset` are gone. For accuracy
-analysis or visualisation, use `clustering.aggregation_result` (a
-[tsam_xarray `AggregationResult`](https://github.com/FZJ-IEK3-VSA/tsam_xarray))
-before serialisation, or rebuild via `flow_system.transform.apply_clustering(...)`
-after loading.
-
-#### Removed: `flow_system.transform.clustering_data()`
-
-The v5 helper that returned a Dataset of *non-constant* time-varying inputs is
-gone. It's not a rename — the v6 clustering pipeline now passes **all**
-time-varying inputs (including constants) to tsam_xarray, so the v5 set isn't
-a meaningful preview anymore. See `cluster_inputs()` below for the v6 equivalent
-(with different semantics).
-
-#### Removed/renamed properties on `Clustering`
-
-| Removed | Replacement |
-|---|---|
-| `Clustering.results` | `Clustering.clustering_result` |
-| `Clustering.dims`, `Clustering.coords` | `clustering.clustering_result.slice_dims` and per-property `.coords` on the returned DataArrays |
-| `Clustering.sel(period=..., scenario=...)` | `clustering.aggregation_result` (pre-IO only) |
-| `Clustering.get_result(...)` | Same as above |
-| `Clustering.n_representatives` | `clustering.n_clusters * (clustering.n_segments or clustering.timesteps_per_cluster)` |
-| `Clustering.timestep_mapping` | `clustering.disaggregate(da)` |
-| `Clustering.expand_data(da)` | `clustering.disaggregate(da)` |
-| `Clustering.build_expansion_divisor()` | Internal-only, replaced by `disaggregate(segment_durations).ffill('time')` |
-| `Clustering.cluster_start_positions` | `np.arange(0, n_clusters * step, step)` |
-| `Clustering.representative_weights` | `Clustering.cluster_occurrences` |
-| `AggregationResults` alias | `Clustering` (use directly) |
-
-#### Removed notebooks
-
-`08d-clustering-multiperiod`, `08e-clustering-internals`, and
-`08f-clustering-segmentation` were merged into `08c-clustering` and
-`08c2-clustering-storage-modes`.
-
-#### NetCDF compatibility
-
-NetCDF files saved with v5 cannot be loaded with v6 — the on-disk format of the
-embedded clustering changed. Re-save by loading in v5 and writing with v6, or
-re-run `transform.cluster()` after upgrading.
-
----
-
 ## ✨ New Features in v6.0.0
 
 ### Time-Series Segmentation
@@ -279,29 +190,6 @@ print(ds.attrs['flixopt_version'])  # e.g., '6.0.0'
 
 ---
 
-### New: `flow_system.transform.cluster_inputs()`
-
-Returns an `xr.Dataset` of **every** variable with a `time` dim — exactly the
-set `cluster()` will pass to tsam_xarray, constants included. Different from
-the removed v5 `clustering_data()`, which filtered constants out.
-
-Use it to enumerate columns for `ClusterConfig(weights={...})`:
-
-```python
-cols = list(flow_system.transform.cluster_inputs())
-target = 'HeatDemand(Q)|fixed_relative_profile'
-weights = {target: 1, **{v: 0 for v in cols if v != target}}
-
-fs_clustered = flow_system.transform.cluster(
-    n_clusters=8, cluster_duration='1D',
-    cluster=ClusterConfig(weights=weights),
-)
-```
-
-Variables omitted from `weights` keep the default weight of **1.0** (still
-influence cluster assignments). Set a variable's weight to `0` to exclude it
-from clustering while keeping it aggregated.
-
 ### Clustering Metadata
 
 After clustering, access structural info via `fs.clustering`:
@@ -310,10 +198,6 @@ After clustering, access structural info via `fs.clustering`:
 fs_clustered.clustering.n_clusters
 fs_clustered.clustering.cluster_assignments
 fs_clustered.clustering.cluster_occurrences
-
-# Accuracy metrics and richer access via the tsam_xarray result directly
-# (pre-IO only — lost after to_netcdf / from_netcdf)
-fs_clustered.clustering.aggregation_result
 ```
 
 ---
@@ -348,6 +232,7 @@ fs_modified = flow_system_modified.transform.apply_clustering(fs_reference.clust
 
 ## Need Help?
 
+- [Migration Guide v7](migration-guide-v7.md) (tsam_xarray clustering backend)
 - [Clustering User Guide](optimization/clustering.md)
 - [Clustering Notebooks](../notebooks/08c-clustering.ipynb)
 - [CHANGELOG](https://github.com/flixOpt/flixopt/blob/main/CHANGELOG.md)

--- a/docs/user-guide/migration-guide-v7.md
+++ b/docs/user-guide/migration-guide-v7.md
@@ -35,7 +35,7 @@ Config objects (`ClusterConfig`, `ExtremeConfig`, `SegmentConfig`) and the
 ### Removed: `data_vars` parameter → use `cluster_on`
 
 The v5/v6 `data_vars` argument ("cluster on these variables only") is replaced by
-`cluster_on`, which keeps the exact same semantics: the clustering is computed on
+`cluster_on`, which keeps the same semantics: the clustering is computed on
 the listed subset and the assignments are applied to the full dataset. Excluded
 variables are aggregated but have **no** influence on the assignments.
 
@@ -62,7 +62,7 @@ among the kept variables (weights may not reference an excluded variable).
     You *can* express exclusion through weights, but a `0` weight is **not** true
     exclusion — tsam clamps it up to a minimal tolerable value, so the variable
     still nudges the assignment (and you must enumerate every column via
-    [`cluster_inputs()`](#new-transformcluster_inputs) to zero the rest). Prefer
+    [`cluster_inputs()`](#cluster-inputs) to zero the rest). Prefer
     `cluster_on` for genuine exclusion. Note this is a correctness feature, not a
     speed one: subset-then-apply is a second pass, so it is not faster than a full
     clustering. Variables omitted from `weights` (without `cluster_on`) keep the
@@ -77,7 +77,7 @@ Auto-weighting from these attributes is gone. Pass weights explicitly via
 
 Not a rename. v7 passes **all** time-varying inputs (including constants) to
 tsam_xarray, so the old "non-constant inputs" preview is no longer meaningful.
-See [`cluster_inputs()`](#new-transformcluster_inputs) for the v7 equivalent
+See [`cluster_inputs()`](#cluster-inputs) for the v7 equivalent
 (different semantics — it includes constants).
 
 ### Removed: metrics, plotting, and original-data serialization
@@ -132,7 +132,7 @@ v7.** Re-run `transform.cluster()` after upgrading, or re-save from v6.
 
 ---
 
-## ✨ New: `transform.cluster_inputs()`
+## ✨ New: `transform.cluster_inputs()` { #cluster-inputs }
 
 Returns an `xr.Dataset` of **every** variable with a `time` dim — exactly what
 `cluster()` feeds to tsam_xarray, **constants included**. Use it to build a

--- a/docs/user-guide/migration-guide-v7.md
+++ b/docs/user-guide/migration-guide-v7.md
@@ -25,7 +25,7 @@ Config objects (`ClusterConfig`, `ExtremeConfig`, `SegmentConfig`) and the
 
 ### Dependencies
 
-- `tsam_xarray >= 0.6.0, < 1` (new; replaces the tsam backend)
+- `tsam_xarray >= 0.6.1, < 1` (new; replaces the tsam backend)
 - `tsam >= 3.4.0, < 4` (still required directly for the config objects)
 
 ---

--- a/docs/user-guide/migration-guide-v7.md
+++ b/docs/user-guide/migration-guide-v7.md
@@ -1,0 +1,171 @@
+# Migration Guide: v6.x → v7.0.0
+
+!!! tip "Quick Start"
+    ```bash
+    pip install --upgrade flixopt
+    ```
+    v7.0.0 has a single breaking change: clustering now runs on
+    [tsam_xarray](https://github.com/FZJ-IEK3-VSA/tsam_xarray) instead of tsam.
+    The `transform.cluster()` call signature is unchanged — only the `Clustering`
+    result object and a few helpers changed.
+
+---
+
+## Overview
+
+| Aspect | v6.x | v7.0.0 |
+|--------|------|--------|
+| **Clustering backend** | per-slice `tsam.aggregate()` loop | single `tsam_xarray.aggregate()` call |
+| **Result object** | `ClusteringResults` (flixopt) | delegates to `tsam_xarray.ClusteringResult` |
+| **Expansion** | `expand_data()` / `timestep_mapping` | `disaggregate()` |
+| **Clustering on a subset** | `data_vars=[...]` | `cluster_on=[...]` |
+
+Config objects (`ClusterConfig`, `ExtremeConfig`, `SegmentConfig`) and the
+`cluster()` / `apply_clustering()` / `expand()` methods are **unchanged**.
+
+### Dependencies
+
+- `tsam_xarray >= 0.6.0, < 1` (new; replaces the tsam backend)
+- `tsam >= 3.4.0, < 4` (still required directly for the config objects)
+
+---
+
+## 💥 Breaking Changes
+
+### Removed: `data_vars` parameter → use `cluster_on`
+
+The v5/v6 `data_vars` argument ("cluster on these variables only") is replaced by
+`cluster_on`, which keeps the exact same semantics: the clustering is computed on
+the listed subset and the assignments are applied to the full dataset. Excluded
+variables are aggregated but have **no** influence on the assignments.
+
+=== "v6.x (Old)"
+    ```python
+    fs_clustered = flow_system.transform.cluster(
+        n_clusters=8, cluster_duration='1D',
+        data_vars=['HeatDemand(Q)|fixed_relative_profile'],  # cluster on this only
+    )
+    ```
+
+=== "v7.0.0 (New)"
+    ```python
+    fs_clustered = flow_system.transform.cluster(
+        n_clusters=8, cluster_duration='1D',
+        cluster_on=['HeatDemand(Q)|fixed_relative_profile'],  # cluster on this only
+    )
+    ```
+
+`cluster_on` combines with `ClusterConfig(weights=...)` to set relative importance
+among the kept variables (weights may not reference an excluded variable).
+
+!!! note "Why not `weights={var: 0}`?"
+    You *can* express exclusion through weights, but a `0` weight is **not** true
+    exclusion — tsam clamps it up to a minimal tolerable value, so the variable
+    still nudges the assignment (and you must enumerate every column via
+    [`cluster_inputs()`](#new-transformcluster_inputs) to zero the rest). Prefer
+    `cluster_on` for genuine exclusion. Note this is a correctness feature, not a
+    speed one: subset-then-apply is a second pass, so it is not faster than a full
+    clustering. Variables omitted from `weights` (without `cluster_on`) keep the
+    default weight of **1.0** and still influence assignments.
+
+### Removed: `TimeSeriesData(clustering_group=..., clustering_weight=...)`
+
+Auto-weighting from these attributes is gone. Pass weights explicitly via
+`ClusterConfig(weights={...})`.
+
+### Removed: `flow_system.transform.clustering_data()`
+
+Not a rename. v7 passes **all** time-varying inputs (including constants) to
+tsam_xarray, so the old "non-constant inputs" preview is no longer meaningful.
+See [`cluster_inputs()`](#new-transformcluster_inputs) for the v7 equivalent
+(different semantics — it includes constants).
+
+### Removed: metrics, plotting, and original-data serialization
+
+`Clustering.metrics` (RMSE/MAE), `clustering.plot.*`, and the
+`include_original_data=...` flag on `to_netcdf()` / `to_dataset()` are gone. For
+accuracy analysis or plotting, use `clustering.aggregation_result` (a tsam_xarray
+`AggregationResult`) **before** serialization, or rebuild via
+`transform.apply_clustering(...)` after loading.
+
+### Expansion: `disaggregate()` replaces `expand_data()` / `timestep_mapping`
+
+```python
+# v6.x
+full = fs.clustering.expand_data(reduced_da)
+# v7.0.0
+full = fs.clustering.disaggregate(reduced_da)
+```
+
+`transform.expand()` (whole-FlowSystem expansion) is unchanged.
+
+### Removed / renamed `Clustering` properties
+
+| Removed (v6.x) | Replacement (v7.0.0) |
+|---|---|
+| `Clustering.results` | `Clustering.clustering_result` |
+| `Clustering.dims`, `Clustering.coords` | `clustering_result.slice_dims` + `.coords` on returned DataArrays |
+| `Clustering.sel(...)`, `Clustering.get_result(...)` | `clustering.aggregation_result` (pre-IO only) |
+| `Clustering.n_representatives` | `n_clusters * (n_segments or timesteps_per_cluster)` |
+| `Clustering.timestep_mapping`, `Clustering.expand_data(da)` | `clustering.disaggregate(da)` |
+| `Clustering.cluster_start_positions` | `np.arange(0, n_clusters * step, step)` |
+| `Clustering.representative_weights` | `Clustering.cluster_occurrences` |
+| `AggregationResults` alias | `Clustering` (use directly) |
+
+**Still available:** `n_clusters`, `timesteps_per_cluster`, `n_original_clusters`,
+`n_segments`, `is_segmented`, `dim_names`, `cluster_assignments`,
+`cluster_occurrences`, `segment_assignments`, `segment_durations`,
+`disaggregate()`, `apply()`, `to_json()` / `from_json()`, plus
+`clustering_result` (tsam_xarray) and `aggregation_result` (pre-IO only).
+
+### Serialization / NetCDF compatibility
+
+The embedded clustering is now serialized via `tsam_xarray.ClusteringResult`
+(`to_dict()` / `from_dict()`). **NetCDF files written by v6 cannot be loaded in
+v7.** Re-run `transform.cluster()` after upgrading, or re-save from v6.
+
+### Removed notebooks
+
+`08d-clustering-multiperiod`, `08e-clustering-internals`, and
+`08f-clustering-segmentation` were removed; their content lives in
+`08c-clustering` and `08c2-clustering-storage-modes`.
+
+---
+
+## ✨ New: `transform.cluster_inputs()`
+
+Returns an `xr.Dataset` of **every** variable with a `time` dim — exactly what
+`cluster()` feeds to tsam_xarray, **constants included**. Use it to build a
+complete `weights` map:
+
+```python
+cols = list(flow_system.transform.cluster_inputs())
+target = 'HeatDemand(Q)|fixed_relative_profile'
+weights = {target: 1, **{v: 0 for v in cols if v != target}}
+
+fs_clustered = flow_system.transform.cluster(
+    n_clusters=8, cluster_duration='1D',
+    cluster=ClusterConfig(weights=weights),
+)
+```
+
+---
+
+## Migration Checklist
+
+- [ ] Replace `data_vars=[...]` with `cluster_on=[...]`
+- [ ] Remove `clustering_group` / `clustering_weight` from `TimeSeriesData`; pass weights explicitly
+- [ ] Replace `expand_data()` / `timestep_mapping` with `disaggregate()`
+- [ ] Update removed `Clustering` properties (see table above)
+- [ ] Move any metrics/plotting to `clustering.aggregation_result` before serialization
+- [ ] Re-run `transform.cluster()` for any NetCDF saved with v6
+
+---
+
+## Need Help?
+
+- [Clustering User Guide](optimization/clustering.md)
+- [Clustering Notebooks](../notebooks/08c-clustering.ipynb)
+- [tsam_xarray](https://github.com/FZJ-IEK3-VSA/tsam_xarray)
+- [CHANGELOG](https://github.com/flixOpt/flixopt/blob/main/CHANGELOG.md)
+- [GitHub Issues](https://github.com/flixOpt/flixopt/issues)

--- a/flixopt/transform_accessor.py
+++ b/flixopt/transform_accessor.py
@@ -1394,11 +1394,6 @@ class TransformAccessor:
                     da_for_clustering = da_for_clustering.drop_vars(dim_name)
                 da_for_clustering = da_for_clustering.expand_dims({dim_name: ds.coords[dim_name].values})
 
-        # Pass user-specified weights to tsam_xarray (validates unknown keys).
-        # cluster_on filters *which* variables the clustering runs on; weights set the
-        # relative importance among the kept ones. Excluded variables are left out of the
-        # aggregation entirely (below) and only receive the resulting assignments — this
-        # is true exclusion, unlike a 0 weight, which tsam clamps up to a tiny epsilon.
         weights = dict(cluster.weights) if (cluster is not None and cluster.weights is not None) else {}
         if cluster_on is not None:
             if not cluster_on:
@@ -1449,30 +1444,15 @@ class TransformAccessor:
         with warnings.catch_warnings():
             warnings.filterwarnings('ignore', category=UserWarning, message='.*minimal value.*exceeds.*')
 
-            if cluster_on is not None:
-                # True exclusion: cluster on the selected variables only, then apply the
-                # resulting assignments to the full variable set. The excluded variables
-                # never influence cluster assignment (a 0 weight would not achieve this,
-                # since tsam clamps it up to a minimal tolerable weight).
-                agg_subset = tsam_xarray.aggregate(
-                    da_for_clustering.sel(variable=cluster_on),
-                    time_dim='time',
-                    cluster_dim='variable',
-                    n_clusters=n_clusters,
-                    weights=weights,
-                    **tsam_kwargs_full,
-                )
-                agg_result = agg_subset.clustering.apply(da_for_clustering, time_dim='time', cluster_dim='variable')
-            else:
-                # Single call: tsam_xarray handles (period, scenario) slicing automatically
-                agg_result = tsam_xarray.aggregate(
-                    da_for_clustering,
-                    time_dim='time',
-                    cluster_dim='variable',
-                    n_clusters=n_clusters,
-                    weights=weights,
-                    **tsam_kwargs_full,
-                )
+            agg_result = tsam_xarray.aggregate(
+                da_for_clustering,
+                time_dim='time',
+                cluster_dim='variable',
+                n_clusters=n_clusters,
+                weights=weights,
+                cluster_on=cluster_on,
+                **tsam_kwargs_full,
+            )
 
         # Rename reserved dims back to original names in the dataset
         if unrename_map:

--- a/flixopt/transform_accessor.py
+++ b/flixopt/transform_accessor.py
@@ -1177,6 +1177,7 @@ class TransformAccessor:
         n_clusters: int,
         cluster_duration: str | float,
         cluster: ClusterConfig | None = None,
+        cluster_on: list[str] | None = None,
         extremes: ExtremeConfig | None = None,
         segments: SegmentConfig | None = None,
         preserve_column_means: bool = True,
@@ -1215,6 +1216,15 @@ class TransformAccessor:
                 Call ``transform.cluster_inputs()`` to list the available variable names.
                 If None, uses default settings (hierarchical clustering with medoid
                 representation) and weight 1.0 for every time-varying variable.
+            cluster_on: Restrict clustering to these variables ("cluster on these only").
+                The clustering is computed on this subset and the resulting cluster
+                assignments are then applied to the full dataset, so the excluded variables
+                are aggregated but have **no** influence on the assignments. This is genuine
+                exclusion — stronger than a 0 weight, which tsam clamps up to a minimal
+                tolerable value. Acts as a *filter on top of* ``weights``: variables listed
+                here may still carry a relative weight via ``ClusterConfig(weights=...)``,
+                but ``weights`` may not reference a variable that ``cluster_on`` excludes.
+                Call ``transform.cluster_inputs()`` to list the available variable names.
             extremes: Optional tsam ``ExtremeConfig`` object specifying how to handle
                 extreme periods (peaks). Use this to ensure peak demand days are captured.
                 Example: ``ExtremeConfig(method='new_cluster', max_value=['demand'])``.
@@ -1257,7 +1267,18 @@ class TransformAccessor:
             ... )
             >>> fs_clustered.optimize(solver)
 
-            Clustering based on specific variables only (zero-weight the rest):
+            Cluster on specific variables only; the rest are aggregated but excluded
+            from the cluster assignment:
+
+            >>> fs_clustered = flow_system.transform.cluster(
+            ...     n_clusters=8,
+            ...     cluster_duration='1D',
+            ...     cluster_on=['HeatDemand(Q)|fixed_relative_profile'],
+            ... )
+
+            A ``weights`` map can *downweight* a variable, but note a 0 weight is not
+            true exclusion (tsam clamps it up to a minimal tolerable value); use
+            ``cluster_on`` when you want a variable to have no influence at all:
 
             >>> from tsam import ClusterConfig
             >>> fs_clustered = flow_system.transform.cluster(
@@ -1265,8 +1286,8 @@ class TransformAccessor:
             ...     cluster_duration='1D',
             ...     cluster=ClusterConfig(
             ...         weights={
-            ...             'HeatDemand(Q)|fixed_relative_profile': 1,
-            ...             'GasSource(Gas)|costs|per_flow_hour': 0,  # ignored for clustering
+            ...             'HeatDemand(Q)|fixed_relative_profile': 2,  # twice the influence
+            ...             'SolarThermal(Q)|fixed_relative_profile': 1,
             ...         }
             ...     ),
             ... )
@@ -1373,11 +1394,29 @@ class TransformAccessor:
                     da_for_clustering = da_for_clustering.drop_vars(dim_name)
                 da_for_clustering = da_for_clustering.expand_dims({dim_name: ds.coords[dim_name].values})
 
-        # Pass user-specified weights to tsam_xarray (validates unknown keys)
-        if cluster is not None and cluster.weights is not None:
-            weights = dict(cluster.weights)
-        else:
-            weights = {}
+        # Pass user-specified weights to tsam_xarray (validates unknown keys).
+        # cluster_on filters *which* variables the clustering runs on; weights set the
+        # relative importance among the kept ones. Excluded variables are left out of the
+        # aggregation entirely (below) and only receive the resulting assignments — this
+        # is true exclusion, unlike a 0 weight, which tsam clamps up to a tiny epsilon.
+        weights = dict(cluster.weights) if (cluster is not None and cluster.weights is not None) else {}
+        if cluster_on is not None:
+            if not cluster_on:
+                raise ValueError('cluster_on must list at least one variable to cluster on.')
+            clusterable = list(ds_for_clustering.data_vars)
+            unknown = [name for name in cluster_on if name not in clusterable]
+            if unknown:
+                raise ValueError(
+                    f'cluster_on contains variables that are not clusterable inputs: {unknown}. '
+                    f'Call transform.cluster_inputs() to list the valid names.'
+                )
+            cluster_on_set = set(cluster_on)
+            masked = [name for name in weights if name not in cluster_on_set]
+            if masked:
+                raise ValueError(
+                    f'ClusterConfig(weights=...) sets weights for variables excluded by cluster_on: '
+                    f'{masked}. Remove them from weights or add them to cluster_on.'
+                )
 
         # Build tsam_kwargs with explicit parameters
         tsam_kwargs_full = {
@@ -1410,15 +1449,30 @@ class TransformAccessor:
         with warnings.catch_warnings():
             warnings.filterwarnings('ignore', category=UserWarning, message='.*minimal value.*exceeds.*')
 
-            # Single call: tsam_xarray handles (period, scenario) slicing automatically
-            agg_result = tsam_xarray.aggregate(
-                da_for_clustering,
-                time_dim='time',
-                cluster_dim='variable',
-                n_clusters=n_clusters,
-                weights=weights,
-                **tsam_kwargs_full,
-            )
+            if cluster_on is not None:
+                # True exclusion: cluster on the selected variables only, then apply the
+                # resulting assignments to the full variable set. The excluded variables
+                # never influence cluster assignment (a 0 weight would not achieve this,
+                # since tsam clamps it up to a minimal tolerable weight).
+                agg_subset = tsam_xarray.aggregate(
+                    da_for_clustering.sel(variable=cluster_on),
+                    time_dim='time',
+                    cluster_dim='variable',
+                    n_clusters=n_clusters,
+                    weights=weights,
+                    **tsam_kwargs_full,
+                )
+                agg_result = agg_subset.clustering.apply(da_for_clustering, time_dim='time', cluster_dim='variable')
+            else:
+                # Single call: tsam_xarray handles (period, scenario) slicing automatically
+                agg_result = tsam_xarray.aggregate(
+                    da_for_clustering,
+                    time_dim='time',
+                    cluster_dim='variable',
+                    n_clusters=n_clusters,
+                    weights=weights,
+                    **tsam_kwargs_full,
+                )
 
         # Rename reserved dims back to original names in the dataset
         if unrename_map:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ nav:
       - Troubleshooting: user-guide/troubleshooting.md
       - Community: user-guide/support.md
     - Migration & Updates:
+      - Migration Guide v7: user-guide/migration-guide-v7.md
       - Migration Guide v6: user-guide/migration-guide-v6.md
       - Migration Guide v5: user-guide/migration-guide-v5.md
       - Migration Guide v3: user-guide/migration-guide-v3.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ tutorials = [
 
 # Full feature set (everything except dev tools)
 full = [
-    "tsam_xarray >= 0.6.0, < 1",  # Time series aggregation for clustering (wraps tsam)
+    "tsam_xarray >= 0.6.1, < 1",  # Time series aggregation for clustering (wraps tsam); 0.6.1 adds aggregate(cluster_on=)
     "tsam >= 3.4.0, < 4",  # Directly imported for ClusterConfig, ExtremeConfig, SegmentConfig
     "pyvis==0.3.2",  # Visualizing FlowSystem Network
     "scipy >= 1.15.1, < 2", # Used by tsam. Prior versions have conflict with highspy. See https://github.com/scipy/scipy/issues/22257
@@ -87,7 +87,7 @@ full = [
 # Development tools and testing
 dev = [
     "xarray<2026.5",  # TODO: drop once linopy ships xarray 2026.3+ compat fix
-    "tsam_xarray==0.6.0",  # Time series aggregation for clustering (wraps tsam)
+    "tsam_xarray==0.6.1",  # Time series aggregation for clustering (wraps tsam)
     "tsam==3.4.0",  # Directly imported for ClusterConfig, ExtremeConfig, SegmentConfig
     "pytest==9.1.1",
     "pytest-xdist==3.8.0",

--- a/tests/test_clustering/test_integration.py
+++ b/tests/test_clustering/test_integration.py
@@ -472,6 +472,129 @@ class TestClusterAdvancedOptions:
         assert len(fs_clustered.clusters) == 2
 
 
+class TestClusterOn:
+    """Tests for the cluster_on convenience argument (subset-then-apply exclusion)."""
+
+    def _two_var_system(self, n_hours: int = 168):
+        pytest.importorskip('tsam')
+        from flixopt import Bus, Effect, Flow, Sink, Source
+        from flixopt.core import TimeSeriesData
+
+        fs = FlowSystem(timesteps=pd.date_range('2024-01-01', periods=n_hours, freq='h'))
+        # Two distinct non-constant profiles so that clustering on one vs the other
+        # yields genuinely different assignments.
+        profile_a = np.sin(np.linspace(0, 14 * np.pi, n_hours)) + 2
+        profile_b = np.cos(np.linspace(0, 3 * np.pi, n_hours)) + 2
+        bus = Bus('electricity')
+        fs.add_elements(
+            Effect('costs', '€', is_standard=True, is_objective=True),
+            Source('grid', outputs=[Flow('grid_in', bus='electricity', size=100)]),
+            Sink(
+                'demand_a',
+                inputs=[
+                    Flow('a_out', bus='electricity', size=100, fixed_relative_profile=TimeSeriesData(profile_a / 100))
+                ],
+            ),
+            Sink(
+                'demand_b',
+                inputs=[
+                    Flow('b_out', bus='electricity', size=100, fixed_relative_profile=TimeSeriesData(profile_b / 100))
+                ],
+            ),
+            bus,
+        )
+        return fs
+
+    VAR_A = 'demand_a(a_out)|fixed_relative_profile'
+    VAR_B = 'demand_b(b_out)|fixed_relative_profile'
+
+    def test_matches_manual_subset_then_apply(self):
+        """cluster_on produces the exact assignments of a manual tsam_xarray subset+apply."""
+        import tsam_xarray
+
+        fs = self._two_var_system()
+        fs_clustered = fs.transform.cluster(n_clusters=2, cluster_duration='1D', cluster_on=[self.VAR_A])
+
+        # Reproduce the intended pipeline directly against tsam_xarray
+        ds = fs.to_dataset(include_solution=False)
+        da = ds[[n for n in ds.data_vars if 'time' in ds[n].dims]].to_dataarray(dim='variable')
+        agg_subset = tsam_xarray.aggregate(
+            da.sel(variable=[self.VAR_A]),
+            time_dim='time',
+            cluster_dim='variable',
+            n_clusters=2,
+            period_duration=24.0,
+            temporal_resolution=1.0,
+        )
+        expected = agg_subset.clustering.apply(da, time_dim='time', cluster_dim='variable')
+
+        np.testing.assert_array_equal(
+            fs_clustered.clustering.cluster_assignments.values,
+            expected.clustering.cluster_assignments.values,
+        )
+
+    def test_subset_selection_drives_assignments(self):
+        """Clustering on A vs on B gives different assignments (subset genuinely matters)."""
+        assignments_a = (
+            self._two_var_system()
+            .transform.cluster(n_clusters=2, cluster_duration='1D', cluster_on=[self.VAR_A])
+            .clustering.cluster_assignments.values
+        )
+        assignments_b = (
+            self._two_var_system()
+            .transform.cluster(n_clusters=2, cluster_duration='1D', cluster_on=[self.VAR_B])
+            .clustering.cluster_assignments.values
+        )
+        assert not np.array_equal(assignments_a, assignments_b)
+
+    def test_excluded_variable_still_aggregated(self):
+        """The excluded variable is kept in the reduced system (aggregated, not dropped)."""
+        fs_clustered = self._two_var_system().transform.cluster(
+            n_clusters=2, cluster_duration='1D', cluster_on=[self.VAR_A]
+        )
+        assert self.VAR_B in set(fs_clustered.transform.cluster_inputs().data_vars)
+
+    def test_no_epsilon_clamp_warning(self):
+        """True exclusion emits no 'minimal tolerable weighting' warning (unlike weight 0)."""
+        import warnings
+
+        with warnings.catch_warnings(record=True) as record:
+            warnings.simplefilter('always')
+            self._two_var_system().transform.cluster(n_clusters=2, cluster_duration='1D', cluster_on=[self.VAR_A])
+        assert not [w for w in record if 'minimal tolerable' in str(w.message)]
+
+    def test_combines_with_weights(self):
+        """cluster_on may carry relative weights among the kept variables."""
+        from tsam import ClusterConfig
+
+        fs_clustered = self._two_var_system().transform.cluster(
+            n_clusters=2,
+            cluster_duration='1D',
+            cluster_on=[self.VAR_A, self.VAR_B],
+            cluster=ClusterConfig(weights={self.VAR_A: 5.0}),
+        )
+        assert fs_clustered.clustering.n_clusters == 2
+
+    def test_empty_list_raises(self):
+        with pytest.raises(ValueError, match='at least one'):
+            self._two_var_system().transform.cluster(n_clusters=2, cluster_duration='1D', cluster_on=[])
+
+    def test_unknown_variable_raises(self):
+        with pytest.raises(ValueError, match='not clusterable'):
+            self._two_var_system().transform.cluster(n_clusters=2, cluster_duration='1D', cluster_on=['does_not_exist'])
+
+    def test_weights_for_excluded_variable_raises(self):
+        from tsam import ClusterConfig
+
+        with pytest.raises(ValueError, match='excluded by cluster_on'):
+            self._two_var_system().transform.cluster(
+                n_clusters=2,
+                cluster_duration='1D',
+                cluster_on=[self.VAR_A],
+                cluster=ClusterConfig(weights={self.VAR_B: 3.0}),
+            )
+
+
 class TestClusteringModuleImports:
     """Tests for flixopt.clustering module imports."""
 

--- a/tests/test_clustering/test_integration.py
+++ b/tests/test_clustering/test_integration.py
@@ -547,6 +547,53 @@ class TestClusterOn:
         )
         assert not np.array_equal(assignments_a, assignments_b)
 
+    def _two_var_system_multiperiod(self, n_hours: int = 168):
+        pytest.importorskip('tsam')
+        from flixopt import Bus, Effect, Flow, Sink, Source
+        from flixopt.core import TimeSeriesData
+
+        fs = FlowSystem(
+            timesteps=pd.date_range('2024-01-01', periods=n_hours, freq='h'),
+            periods=pd.Index([2025, 2030], name='period'),
+        )
+        profile_a = np.sin(np.linspace(0, 14 * np.pi, n_hours)) + 2
+        profile_b = np.cos(np.linspace(0, 3 * np.pi, n_hours)) + 2
+        bus = Bus('electricity')
+        fs.add_elements(
+            Effect('costs', '€', is_standard=True, is_objective=True),
+            Source('grid', outputs=[Flow('grid_in', bus='electricity', size=100)]),
+            Sink(
+                'demand_a',
+                inputs=[
+                    Flow('a_out', bus='electricity', size=100, fixed_relative_profile=TimeSeriesData(profile_a / 100))
+                ],
+            ),
+            Sink(
+                'demand_b',
+                inputs=[
+                    Flow('b_out', bus='electricity', size=100, fixed_relative_profile=TimeSeriesData(profile_b / 100))
+                ],
+            ),
+            bus,
+        )
+        return fs
+
+    def test_multiperiod_matches_single_period_per_slice(self):
+        """cluster_on is applied per slice: each period's assignments match the single-period result."""
+        single = (
+            self._two_var_system()
+            .transform.cluster(n_clusters=2, cluster_duration='1D', cluster_on=[self.VAR_A])
+            .clustering.cluster_assignments
+        )
+        multi = (
+            self._two_var_system_multiperiod()
+            .transform.cluster(n_clusters=2, cluster_duration='1D', cluster_on=[self.VAR_A])
+            .clustering.cluster_assignments
+        )
+        assert 'period' in multi.dims
+        for period in multi['period'].values:
+            np.testing.assert_array_equal(multi.sel(period=period).values, single.values)
+
     def test_excluded_variable_still_aggregated(self):
         """The excluded variable is kept in the reduced system (aggregated, not dropped)."""
         fs_clustered = self._two_var_system().transform.cluster(


### PR DESCRIPTION
## Summary

Adds `transform.cluster(cluster_on=[...])` — "cluster on these variables only",
restoring the ergonomics of the removed v5/v6 `data_vars`. The clustering is computed
on the listed subset and the assignments are applied to the full dataset, so excluded
variables are aggregated but have **no** influence on the assignment.

Built on **tsam_xarray 0.6.1**, which adds `aggregate(cluster_on=)`: flixopt delegates
straight to it (single `aggregate()` call, no subset+apply plumbing on our side).

### Why not `weights={var: 0}`?

A `0` weight is not genuine exclusion — tsam clamps it up to a *minimal tolerable
weighting* (with a warning), so the variable still nudges the assignment, and you'd have
to enumerate every column to zero the rest. `cluster_on` is a hard structural selection;
`weights` stays purely about relative importance among the kept variables.

```python
# v5/v6
fs.transform.cluster(n_clusters=8, cluster_duration='1D',
                     data_vars=['HeatDemand(Q)|fixed_relative_profile'])
# v7 (this PR)
fs.transform.cluster(n_clusters=8, cluster_duration='1D',
                     cluster_on=['HeatDemand(Q)|fixed_relative_profile'])
```

`cluster_on` composes with `ClusterConfig(weights=...)` (weights may not reference an
excluded variable). Not a performance feature — subset-then-apply is a second pass, on
par with a full clustering.

## Dependency

- `tsam_xarray >= 0.6.1` (was `>= 0.6.0`); dev pin `== 0.6.1`. 0.6.1 adds
  `aggregate(cluster_on=)` and validates `extremes` that reference excluded variables.

## Docs

- New `migration-guide-v7.md` (v6→v7 tsam_xarray backend); the `data_vars` section leads
  with `cluster_on`. Stable `{ #cluster-inputs }` anchor for the `cluster_inputs()` links.
- `migration-guide-v6.md`: removed tsam_xarray content that had been misplaced into the
  v5→v6 guide (it shipped in v7); cross-linked to v7.
- Registered v7 in the mkdocs nav.

## Tests

`TestClusterOn` (9 cases): equivalence to a manual subset+apply, subset selection drives
assignments, **multiperiod per-slice** correctness, excluded var retained, no
epsilon-clamp warning, weights combination, and error paths. Full clustering suite: 252
passed. ruff clean.

## Review-finding resolutions

- **Fixed** — `cluster_inputs()` doc anchor: added explicit `{ #cluster-inputs }` and
  repointed both links (robust across slugify configs; the emoji made the auto-slug fragile).
- **Fixed** — nitpick "exact same" → "same semantics".
- **Fixed** — added multiperiod cluster_on coverage.
- **Skipped** — flixopt-level extremes-vs-cluster_on validation: **redundant**, tsam_xarray
  0.6.1 already raises a clear `ValueError` ("extremes references coordinates {...} that
  cluster_on excluded").

## Note

tsam_xarray 0.6.1 is released (GitHub tag `v0.6.1`); at time of writing PyPI was still
ingesting it. Local dev/CI resolves once it lands on PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `cluster_on` option to control which time-varying inputs define clustering assignments, while retaining other time-varying variables in the reduced output via aggregation.
  * Updated clustering execution to use the selected inputs directly and enforce validation (e.g., empty/unknown selections, and incompatible weights).
* **Documentation**
  * Expanded the v5→v6 migration guide with additional v6 capabilities and updated clustering metadata details.
  * Added a full v6.x→v7 migration guide and linked it from the support section.
* **Tests**
  * Added integration tests for `cluster_on`, including multi-period consistency and error handling.
* **Chores**
  * Updated the `tsam_xarray` version used for optional installs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->