### PR TITLE
fix: support tsam_xarray 0.6.5 by using cluster_counts

### DIFF
--- a/flixopt/transform_accessor.py
+++ b/flixopt/transform_accessor.py
@@ -88,7 +88,7 @@ class _ReducedFlowSystemBuilder:
         Returns:
             DataArray with dims [cluster, period?, scenario?].
         """
-        return self._unrename(self._agg_result.cluster_weights.rename('cluster_weight'))
+        return self._unrename(self._agg_result.cluster_counts.rename('cluster_weight'))
 
     def build_typical_periods(self) -> dict[str, xr.DataArray]:
         """Build typical periods DataArrays with (cluster, time, ...) shape.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ tutorials = [
 
 # Full feature set (everything except dev tools)
 full = [
-    "tsam_xarray >= 0.6.1, < 1",  # Time series aggregation for clustering (wraps tsam); 0.6.1 adds aggregate(cluster_on=)
+    "tsam_xarray >= 0.6.5, < 1",  # Time series aggregation for clustering (wraps tsam); 0.6.5 renames cluster_weights to cluster_counts
     "tsam >= 3.4.0, < 4",  # Directly imported for ClusterConfig, ExtremeConfig, SegmentConfig
     "pyvis==0.3.2",  # Visualizing FlowSystem Network
     "scipy >= 1.15.1, < 2", # Used by tsam. Prior versions have conflict with highspy. See https://github.com/scipy/scipy/issues/22257
@@ -87,7 +87,7 @@ full = [
 # Development tools and testing
 dev = [
     "xarray<2026.5",  # TODO: drop once linopy ships xarray 2026.3+ compat fix
-    "tsam_xarray==0.6.1",  # Time series aggregation for clustering (wraps tsam)
+    "tsam_xarray==0.6.5",  # Time series aggregation for clustering (wraps tsam)
     "tsam==3.4.0",  # Directly imported for ClusterConfig, ExtremeConfig, SegmentConfig
     "pytest==9.1.1",
     "pytest-xdist==3.8.0",


### PR DESCRIPTION
## Problem

`tsam_xarray` 0.6.5 renamed `AggregationResult.cluster_weights` to `cluster_counts`, keeping the old name as a deprecated property. Since our pytest config promotes warnings to errors (`pyproject.toml:214`), the resulting `FutureWarning` fails almost the entire clustering suite on any environment that resolves to 0.6.5 — and the `full` extra's current floor of `>= 0.6.1, < 1` already permits it, so a fresh install hits this today.

`tests/test_clustering` on `main`:

| | tsam_xarray 0.6.1 | 0.6.5 |
|---|---|---|
| `main` | 286 passed | **254 failed**, 32 passed |
| this PR | — | 286 passed |

Every one of the 254 failures is the same `FutureWarning: AggregationResult.cluster_weights is deprecated; use cluster_counts instead.`

## Change

- `transform_accessor.py` — `cluster_weights` → `cluster_counts` in `build_cluster_weights`
- `pyproject.toml` — `full`: `>= 0.6.1` → `>= 0.6.5`; `dev`: `==0.6.1` → `==0.6.5`

`cluster_counts` does not exist before 0.6.5, so the floor has to move with the rename rather than merely allowing the new version. The two changes are coupled and can't land separately.

## Bonus: expand() gets ~3.6x faster

0.6.5 also vectorises unsegmented disaggregation, which speeds up `expand()` with no changes on our side. Measured on a 3-year, 40-cluster, 84-variable system, min of 10 runs:

| tsam_xarray | `expand()` |
|---|---|
| 0.6.1 | 0.262 s |
| 0.6.5 | 0.073 s |

`cluster()` is unaffected (0.096 s vs 0.095 s, within noise). Users on the `full` extra already resolved to 0.6.5 and have this; the exact pin in `dev` was holding CI and development environments on the slow path.

## Note for #748

This touches `build_cluster_weights`, which #748 (reapply #739) also rewrites. Whoever lands that should keep `cluster_counts` — the rename is independent of the dim-naming work and is required for 0.6.5 either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cluster weighting metadata when building reduced flow systems.

* **Chores**
  * Updated the optional full and development dependency requirements for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->