### PR TITLE
ci: pin ruff to the version in pyproject dev extra

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,6 +24,7 @@ concurrency:
 
 env:
   PYTHON_VERSION: "3.11"
+  RUFF_VERSION: "0.15.21"  # Keep in sync with the ruff pin in pyproject.toml [dev]
   MPLBACKEND: Agg
   PLOTLY_RENDERER: json
   FLIXOPT_CI: false
@@ -45,8 +46,8 @@ jobs:
 
       - name: Run Ruff
         run: |
-          uvx ruff check . --output-format=github
-          uvx ruff format --check --diff .
+          uvx ruff@${{ env.RUFF_VERSION }} check . --output-format=github
+          uvx ruff@${{ env.RUFF_VERSION }} format --check --diff .
 
   test:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Problem

The lint job runs `uvx ruff` **unpinned**, so it silently tracks whatever ruff released most recently — while the repo pins `ruff==0.15.21` in `[dev]` (which is what pre-commit and local runs use).

Ruff 0.16.0 shipped recently and began formatting Python code blocks inside Markdown. That flags **26 docs files** and fails `lint` on every open PR regardless of its contents — #755, #754 and #753 are all red on this, and since `lint` gates `test`, everything downstream is `skipping`.

Verified on a clean checkout, same tree, two ruff versions:

| ruff | `check` | `format --check` |
|---|---|---|
| 0.15.21 (repo pin) | passed | clean |
| 0.16.0 (what CI used) | passed | **26 markdown files** flagged |

Zero Python files are flagged either way — this is entirely the new Markdown behaviour.

## Change

Pin the lint job to the same ruff the `dev` extra specifies, via a `RUFF_VERSION` env var alongside the existing `PYTHON_VERSION`. `setup-uv` is already pinned to `0.10.9` in this workflow, so this matches the surrounding convention.

## Follow-up

This deliberately does *not* reformat the docs. Adopting 0.16.0 should happen through dependabot #752 (`ruff 0.15.21 → 0.16.0`), where the 26-file docs reformat can land as a reviewed change together with the bump, and `RUFF_VERSION` updated in the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)