### PR TITLE
fix: support linopy 0.9.0

### DIFF
--- a/flixopt/components.py
+++ b/flixopt/components.py
@@ -17,7 +17,13 @@ from .core import PlausibilityError
 from .elements import Component, ComponentModel, Flow
 from .features import InvestmentModel, PiecewiseModel
 from .interface import InvestParameters, PiecewiseConversion, StatusParameters
-from .modeling import BoundingPatterns, _scalar_safe_isel, _scalar_safe_isel_drop, _scalar_safe_reduce
+from .modeling import (
+    BoundingPatterns,
+    _scalar_safe_isel,
+    _scalar_safe_isel_drop,
+    _scalar_safe_reduce,
+    _set_constraint_lhs,
+)
 from .structure import FlowSystemModel, VariableCategory, register_class_for_io
 
 if TYPE_CHECKING:
@@ -849,7 +855,10 @@ class TransmissionModel(ComponentModel):
         )
 
         if (self.element.absolute_losses is not None) and np.any(self.element.absolute_losses != 0):
-            con_transmission.lhs += in_flow.submodel.status.status * self.element.absolute_losses
+            _set_constraint_lhs(
+                con_transmission,
+                con_transmission.lhs + in_flow.submodel.status.status * self.element.absolute_losses,
+            )
 
         return con_transmission
 

--- a/flixopt/elements.py
+++ b/flixopt/elements.py
@@ -16,7 +16,7 @@ from .config import CONFIG
 from .core import PlausibilityError
 from .features import InvestmentModel, StatusModel
 from .interface import InvestParameters, StatusParameters
-from .modeling import BoundingPatterns, ModelingPrimitives, ModelingUtilitiesAbstract
+from .modeling import BoundingPatterns, ModelingPrimitives, ModelingUtilitiesAbstract, _set_constraint_lhs
 from .structure import (
     Element,
     ElementModel,
@@ -1033,7 +1033,7 @@ class BusModel(ElementModel):
             )
 
             # Σ(inflows) + virtual_supply = Σ(outflows) + virtual_demand
-            eq_bus_balance.lhs += self.virtual_supply - self.virtual_demand
+            _set_constraint_lhs(eq_bus_balance, eq_bus_balance.lhs + self.virtual_supply - self.virtual_demand)
 
             # Add penalty shares as temporal effects (time-dependent)
             from .effects import PENALTY_EFFECT_LABEL

--- a/flixopt/features.py
+++ b/flixopt/features.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 import linopy
 import numpy as np
 
-from .modeling import BoundingPatterns, ModelingPrimitives, ModelingUtilities
+from .modeling import BoundingPatterns, ModelingPrimitives, ModelingUtilities, _set_constraint_lhs
 from .structure import FlowSystemModel, Submodel, VariableCategory
 
 if TYPE_CHECKING:
@@ -664,7 +664,9 @@ class ShareAllocationModel(Submodel):
             # Add it to the total (cluster_weight handles cluster representation, defaults to 1.0)
             # Sum over all temporal dimensions (time, and cluster if present)
             weighted_per_timestep = self.total_per_timestep * self._model.weights.get('cluster', 1.0)
-            self._eq_total.lhs -= weighted_per_timestep.sum(dim=self._model.temporal_dims)
+            _set_constraint_lhs(
+                self._eq_total, self._eq_total.lhs - weighted_per_timestep.sum(dim=self._model.temporal_dims)
+            )
 
     def add_share(
         self,
@@ -694,7 +696,7 @@ class ShareAllocationModel(Submodel):
                 raise ValueError('Cannot add share with scenario-dim to a model without scenario-dim')
 
         if name in self.shares:
-            self.share_constraints[name].lhs -= expression
+            _set_constraint_lhs(self.share_constraints[name], self.share_constraints[name].lhs - expression)
         else:
             # Temporal shares (with 'time' dim) are segment totals that need division
             category = VariableCategory.SHARE if 'time' in dims else None
@@ -710,6 +712,6 @@ class ShareAllocationModel(Submodel):
             )
 
             if 'time' not in dims:
-                self._eq_total.lhs -= self.shares[name]
+                _set_constraint_lhs(self._eq_total, self._eq_total.lhs - self.shares[name])
             else:
-                self._eq_total_per_timestep.lhs -= self.shares[name]
+                _set_constraint_lhs(self._eq_total_per_timestep, self._eq_total_per_timestep.lhs - self.shares[name])

--- a/flixopt/modeling.py
+++ b/flixopt/modeling.py
@@ -76,6 +76,22 @@ def _scalar_safe_reduce(data: xr.DataArray | Any, dim: str, method: str = 'mean'
     return data
 
 
+def _set_constraint_lhs(constraint: linopy.Constraint, lhs) -> None:
+    """Replace a constraint's LHS, compatibly across linopy versions.
+
+    Incremental accumulators (e.g. share totals) must mutate a constraint after
+    it is created. linopy >= 0.8 exposes ``Constraint.update(lhs=...)`` and
+    deprecates the ``.lhs`` setter (flixopt escalates that deprecation to an
+    error); linopy < 0.8 has only the setter, which is not deprecated there.
+    Dispatch on whichever API the installed linopy provides so the same call
+    works — and warns on neither — under both.
+    """
+    if hasattr(constraint, 'update'):
+        constraint.update(lhs=lhs)
+    else:
+        constraint.lhs = lhs
+
+
 def _xr_allclose(a: xr.DataArray, b: xr.DataArray, rtol: float = 1e-5, atol: float = 1e-8) -> bool:
     """Check if two DataArrays are element-wise equal within tolerance.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "pandas >= 2.0.0, < 3",
     "xarray >=2024.2.0, <2026.5", # CalVer: allow through next calendar year
     # Optimization and data handling
-    "linopy >=0.5.1, <0.8", # Widened from patch pin to minor range
+    "linopy >=0.5.1, <0.10", # Widened from patch pin to minor range
     "netcdf4 >=1.6.1, <1.7.5",  # 1.7.4 missing wheels, revert to < 2 later
     # Utilities
     "pyyaml >= 6.0.0, < 7",

--- a/tests/test_clustering/test_expansion_regression.py
+++ b/tests/test_clustering/test_expansion_regression.py
@@ -93,8 +93,13 @@ class TestNonSegmentedExpansion:
         fs_e = fs_c.transform.expand()
 
         sol = fs_e.solution
-        # Storage dispatch varies by solver — check charge_state is non-trivial
-        assert float(np.nansum(sol['S|charge_state'].values)) > 0
+        # Gas price and boiler efficiency are flat, so storage earns nothing and its
+        # dispatch is degenerate: every cycling depth (including none) is optimal, and
+        # which one the solver lands on shifts with solver and linopy version. Assert
+        # the expansion produced a usable charge_state, not one arbitrary optimum.
+        charge_state = sol['S|charge_state'].values
+        assert charge_state.shape == (N_HOURS + 1,)
+        assert np.isfinite(charge_state).all()
         # Net discharge should be ~0 (balanced storage)
         assert float(np.nansum(sol['S|netto_discharge'].values)) == pytest.approx(0, abs=1e-4)
 

--- a/tests/test_math/test_clustering.py
+++ b/tests/test_math/test_clustering.py
@@ -336,11 +336,15 @@ class TestClusteringExact:
         discharge_fr = fs.solution['Battery(discharge)|flow_rate'].values[:, :4]
         assert_allclose(discharge_fr, [[0, 50, 0, 50], [0, 50, 0, 50]], atol=1e-5)
 
+        # Both clusters carry identical data, so the absolute SOC offset is degenerate:
+        # any level in [50, 100] is optimal. Assert what the model actually determines --
+        # the charge/discharge pattern and the cyclic wrap -- not one arbitrary offset.
         charge_state = fs.solution['Battery|charge_state']
         assert charge_state.dims == ('cluster', 'time')
-        cs_c0 = charge_state.isel(cluster=0).values[:5]
-        cs_c1 = charge_state.isel(cluster=1).values[:5]
-        assert_allclose(cs_c0, [50, 50, 0, 50, 0], atol=1e-5)
-        assert_allclose(cs_c1, [100, 100, 50, 100, 50], atol=1e-5)
+        for cluster in (0, 1):
+            cs = charge_state.isel(cluster=cluster).values[:5]
+            assert_allclose(np.diff(cs), [0, -50, 50, -50], atol=1e-5)
+            assert_allclose(cs[0], cs[3], atol=1e-5)  # cyclic wrap within the cluster
+            assert 50 - 1e-5 <= cs[0] <= 100 + 1e-5
 
         assert_allclose(fs.solution['objective'].item(), 100.0, rtol=1e-5)


### PR DESCRIPTION
Makes flixopt build and solve on linopy 0.9.0, and widens the pin to `>=0.5.1,<0.10`.

## What broke

linopy 0.9 deprecates assignment to `Constraint.lhs` in favour of `Constraint.update(lhs=...)`. flixopt escalates `DeprecationWarning` from its own package to an error (`error::DeprecationWarning:flixopt`), so the accumulator in `ShareAllocationModel` took down every effect-bearing model at build time — **668 of 1261 tests failed, all from this single root cause.**

## The fix

`modeling._set_constraint_lhs()` dispatches on whichever API the installed linopy provides:

- linopy >= 0.8 → `Constraint.update(lhs=...)` (the `.lhs` setter is deprecated there)
- linopy < 0.8 → the `.lhs` setter (`update()` does not exist, and the setter is not deprecated)

All six in-place LHS mutations route through it: the share accumulators in `features.py`, the bus imbalance term in `elements.py`, and transmission absolute losses in `components.py`. Term order is unchanged on every version, so the existing white-box constraint tests still hold.

## Two tests were pinning degenerate optima

Both flipped under 0.9 because its internal reordering makes HiGHS land on a different vertex of the same optimal face. **The objective and all flow rates are identical** — only the arbitrary part of the solution moved. This is the degeneracy already diagnosed in #733, not a semantics change.

- `test_storage_cyclic_charge_discharge_pattern` — the two clusters carry identical data, so which one gets which absolute SOC offset is arbitrary (any level in `[50, 100]` is optimal). Now asserts the SOC deltas and the cyclic wrap, which are uniquely determined.
- `test_expanded_storage` — gas price and boiler efficiency are flat, so storage earns nothing and every cycling depth (including none) is optimal. The old `nansum(charge_state) > 0` passed on linopy 0.7 only on ~1e-5 numerical noise.

## Verification

Full suite minus `slow`, 1261 tests:

| linopy | result |
| --- | --- |
| 0.9.0 | 1259 passed, 2 skipped |
| 0.8.0 | 1259 passed, 2 skipped |
| 0.7.0 | 1259 passed, 2 skipped |
| 0.6.7 | 1259 passed, 2 skipped |
| 0.5.1 | linopy↔xarray incompat only (see below) |

0.5.1 fails solely through the known incompatibility between old linopy and xarray >= 2026 — `TypeError: Passing a Dataset as data_vars` raised inside `linopy/expressions.py`, before any flixopt code runs. Paired with xarray 2025.7.1 it passes, so the `>=0.5.1` lower bound remains honest.

Not run: `slow` tests, notebooks, examples.

## Relationship to other PRs

- **#729** (linopy v1 arithmetic semantics) carries a `_set_constraint_lhs` of the same design; this PR deliberately reuses its name and shape to keep the conflict minimal. That PR's merge gate was "after linopy v0.9.0 is released" — 0.9.0 is now on PyPI, so if you'd rather merge #729 first, this PR reduces to the pin bump plus the two test changes.
- **#750** (Dependabot) proposes the identical pin bump, but without the code change it cannot pass CI.

## Pre-existing issue noticed, not addressed here

The **expanded** clustered `charge_state` can far exceed capacity (241 against a cap of 50 under gurobi), and the clustered `charge_state` goes negative. Both behave identically on linopy 0.7.0, so they predate this work — plausibly the same root as #735 (`initial_charge_state` ignored in cyclic `cluster_mode`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)