### PR TITLE
ci: always report lint and test on pull requests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,6 +16,10 @@ on:
     branches: ["**"]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: read  # `changes` reads the PR's file list via gh
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -45,9 +49,14 @@ jobs:
             echo 'source=true' >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          paths=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json files --jq '.files[].path')
-          # Treat an unreadable or truncated listing as a source change, so a
-          # detection failure costs a test run rather than skipping one.
+          # Treat a failed, empty or truncated listing as a source change, so a
+          # detection failure costs a test run rather than skipping one. The guard
+          # is required: steps run under `bash -e`, where a failing command
+          # substitution aborts the step instead of falling through.
+          if ! paths=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json files --jq '.files[].path'); then
+            echo 'source=true' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           if [[ -z "$paths" ]] || grep -qE '^(flixopt/|tests/|pyproject\.toml$|\.github/workflows/)' <<< "$paths"; then
             echo 'source=true' >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,14 +8,12 @@ on:
       - 'tests/**'
       - 'pyproject.toml'
       - '.github/workflows/**'
+  # No paths filter here: lint and test are required checks, and a workflow that
+  # never triggers never reports, leaving such PRs permanently blocked. The filter
+  # lives in the `changes` job below, which skips the expensive steps instead.
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches: ["**"]
-    paths:
-      - 'flixopt/**'
-      - 'tests/**'
-      - 'pyproject.toml'
-      - '.github/workflows/**'
   workflow_dispatch:
 
 concurrency:
@@ -30,6 +28,32 @@ env:
   FLIXOPT_CI: false
 
 jobs:
+  changes:
+    name: Detect source changes
+    runs-on: ubuntu-24.04
+    outputs:
+      source: ${{ steps.detect.outputs.source }}
+    steps:
+      - name: Detect source changes
+        id: detect
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [[ "${{ github.event_name }}" != 'pull_request' ]]; then
+            echo 'source=true' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          paths=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json files --jq '.files[].path')
+          # Treat an unreadable or truncated listing as a source change, so a
+          # detection failure costs a test run rather than skipping one.
+          if [[ -z "$paths" ]] || grep -qE '^(flixopt/|tests/|pyproject\.toml$|\.github/workflows/)' <<< "$paths"; then
+            echo 'source=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'source=false' >> "$GITHUB_OUTPUT"
+          fi
+
   lint:
     runs-on: ubuntu-24.04
     steps:
@@ -52,7 +76,7 @@ jobs:
   test:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    needs: lint
+    needs: [lint, changes]
     strategy:
       fail-fast: false
       matrix:
@@ -70,9 +94,11 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
+        if: needs.changes.outputs.source == 'true'
         run: uv pip install --system .[dev]
 
       - name: Run tests
+        if: needs.changes.outputs.source == 'true'
         run: |
           if [[ "${{ github.event.pull_request.draft }}" == "true" ]]; then
             # Draft PR: skip examples, slow, and deprecated_api
@@ -81,6 +107,10 @@ jobs:
             # Ready PR & main push: examples excluded via addopts
             pytest -v --numprocesses=auto
           fi
+
+      - name: Report skipped tests
+        if: needs.changes.outputs.source != 'true'
+        run: echo 'No changes under flixopt/, tests/, pyproject.toml or .github/workflows/ - tests skipped.'
 
   test-examples:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Problem

The ruleset on `main` requires these checks:

```
lint, test (3.11), test (3.12), test (3.13), test (3.14)
```

#562 added a `paths:` filter to the `pull_request` trigger of `tests.yaml`. A workflow that never triggers never reports its checks, and required checks that never report leave the PR permanently `BLOCKED` — there is no failure to look at, just nothing.

Release PRs change exactly three files — `CHANGELOG.md`, `.release-please-manifest.json`, `CITATION.cff` — none of which match the filter. So **#740 cannot merge**, and neither can any future release PR. #737 (release 7.2.1) ran `lint` and `test (3.11-3.14)` normally on the same three files; it merged the day before #562 landed.

Any docs-only or metadata-only PR hits the same wall.

## Change

The filter moves from the trigger into a `changes` job that reads the PR's file list, and the expensive steps become conditional on its output. The jobs still run and still report; only the work is skipped.

Cost for a docs-only PR is a runner start rather than a full matrix, so #562's intent is preserved. The `push` trigger keeps its `paths:` filter — nothing requires checks there.

Detection defaults to `true` when the file list is empty or unreadable, so a lookup failure wastes a test run rather than silently skipping one.

Verified the classifier against the PRs it has to get right:

| PR | files | detected |
|---|---|---|
| #740 (release) | CHANGELOG, manifest, CITATION | `source=false` → skip |
| #757 | `flixopt/io.py`, tests | `source=true` → run |
| #755 | `pyproject.toml`, `flixopt/` | `source=true` → run |
| #753 (dependabot) | `pyproject.toml` | `source=true` → run |

## Merge order

This PR touches `.github/workflows/**`, so it triggers CI itself and will show the required checks passing normally.

Merging it to `main` regenerates #740 and discards the hand-edit that retargeted it from 8.0.0 to 7.3.0. Either merge #740 first via admin override, or merge this and expect #740 to need retargeting again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Pull requests now consistently trigger the validation workflow.
  * Testing runs automatically when source-relevant files change.
  * Validation is skipped for changes that do not affect source files, with the outcome clearly reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->