### PR TITLE
docs: correct the 8.0.0 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,15 @@ For more details regarding the individual PRs and contributors, please refer to 
 
 ## [8.0.0](https://github.com/flixOpt/flixopt/compare/v7.2.1...v8.0.0) (2026-07-27)
 
+!!! note
 
-### ⚠ BREAKING CHANGES
-
-* the serialized clustering format changed - slice dims are now stored as 'period' (was '_period') plus a new 'dim_names' key. Clustering artifacts saved to JSON/netCDF by an older flixopt no longer load for apply_clustering()/expand() in this version; re-run transform.cluster() to regenerate them. Fresh clustering and same-version round-trips are unaffected. Also raises the minimum tsam_xarray to 0.6.4.
+    Despite the major version, this release contains **no breaking changes**.
+    The clustering format change that justified the bump ([#739](https://github.com/flixOpt/flixopt/issues/739))
+    was reverted before release ([#746](https://github.com/flixOpt/flixopt/issues/746)),
+    but its `BREAKING CHANGE` footer still drove the version number.
+    Serialized clustering is unchanged from 7.2.1, and files written by 6.x -
+    which stopped loading under 7.0 - load again as of
+    [#757](https://github.com/flixOpt/flixopt/issues/757).
 
 ### Bug Fixes
 
@@ -26,9 +31,9 @@ For more details regarding the individual PRs and contributors, please refer to 
 * support linopy 0.9.0 ([#758](https://github.com/flixOpt/flixopt/issues/758)) ([051480b](https://github.com/flixOpt/flixopt/commit/051480b9af70933edf6afb24bfeef8e0aa7e0c10))
 
 
-### Code Refactoring
+### Reverts
 
-* drop clustering dim-rename layer via tsam-xarray DimNames ([#739](https://github.com/flixOpt/flixopt/issues/739)) ([cc56774](https://github.com/flixOpt/flixopt/commit/cc56774d31e05d637ee40424ec64af276716cc2f))
+* drop clustering dim-rename layer via tsam-xarray DimNames ([#739](https://github.com/flixOpt/flixopt/issues/739)) was merged and then reverted ([#746](https://github.com/flixOpt/flixopt/issues/746)) before release, so the serialized clustering format is unchanged from 7.2.1.
 
 ## [7.2.1](https://github.com/flixOpt/flixopt/compare/v7.2.0...v7.2.1) (2026-07-21)
 


### PR DESCRIPTION
## Problem

8.0.0 shipped with a `⚠ BREAKING CHANGES` notice describing a clustering format change that **is not in the release**.

#739 introduced that change and #746 reverted it before release. Release-please does not pair a revert with its original, so the `BREAKING CHANGE:` footer both drove the major version bump and rendered into the published notes.

The release is in fact non-breaking. Verified by loading artifacts from released versions against this code:

| written by | loads | expands |
|---|---|---|
| 7.2.3 (plain, multi-period) | yes | yes |
| 6.2.1 (plain, solved, multi-period, period+scenario) | yes | yes |
| 6.1.0 (plain) | yes | yes |

Serialized clustering is unchanged from 7.2.1, and 6.x files that stopped loading under 7.0 load again as of #757 — so 8.0.0 is *more* compatible than its predecessor, not less.

## Change

`CHANGELOG.md` only, for the already-published 8.0.0 section:

- the breaking-change notice becomes a note explaining why the major carries no breaking change
- #739 moves from `Code Refactoring` to `Reverts`, stating it was reverted before release

Uses the `!!! note` admonition already used elsewhere in this file, so it renders in the docs site.

Typed `docs:` so it does not itself trigger a release. The v8.0.0 GitHub release notes are being corrected separately, in place.

## Follow-up

8.0.1 should pick up #755 (raises the `tsam_xarray` floor to 0.6.5). Without it, anyone resolving to 0.6.5 gets a `cluster_weights` deprecation warning — noisy at runtime, and a hard failure under `-W error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)