### PR TITLE
fix: support tsam_xarray 0.6.5 by using cluster_counts

### DIFF
--- a/flixopt/transform_accessor.py
+++ b/flixopt/transform_accessor.py
@@ -88,7 +88,7 @@ class _ReducedFlowSystemBuilder:
         Returns:
             DataArray with dims [cluster, period?, scenario?].
         """
-        return self._unrename(self._agg_result.cluster_weights.rename('cluster_weight'))
+        return self._unrename(self._agg_result.cluster_counts.rename('cluster_weight'))
 
     def build_typical_periods(self) -> dict[str, xr.DataArray]:
         """Build typical periods DataArrays with (cluster, time, ...) shape.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ tutorials = [
 
 # Full feature set (everything except dev tools)
 full = [
-    "tsam_xarray >= 0.6.1, < 1",  # Time series aggregation for clustering (wraps tsam); 0.6.1 adds aggregate(cluster_on=)
+    "tsam_xarray >= 0.6.5, < 1",  # Time series aggregation for clustering (wraps tsam); 0.6.5 renames cluster_weights to cluster_counts
     "tsam >= 3.4.0, < 4",  # Directly imported for ClusterConfig, ExtremeConfig, SegmentConfig
     "pyvis==0.3.2",  # Visualizing FlowSystem Network
     "scipy >= 1.15.1, < 2", # Used by tsam. Prior versions have conflict with highspy. See https://github.com/scipy/scipy/issues/22257
@@ -87,7 +87,7 @@ full = [
 # Development tools and testing
 dev = [
     "xarray<2026.8",  # TODO: drop once linopy ships xarray 2026.3+ compat fix
-    "tsam_xarray==0.6.1",  # Time series aggregation for clustering (wraps tsam)
+    "tsam_xarray==0.6.5",  # Time series aggregation for clustering (wraps tsam)
     "tsam==3.4.0",  # Directly imported for ClusterConfig, ExtremeConfig, SegmentConfig
     "pytest==9.1.1",
     "pytest-xdist==3.8.0",


### PR DESCRIPTION
## Problem

`tsam_xarray` 0.6.5 renamed `AggregationResult.cluster_weights` to `cluster_counts`, keeping the old name as a deprecated property. The `full` extra allows `>= 0.6.1`, so a fresh install resolves to 0.6.5 and every `cluster()` call emits a `FutureWarning` — and fails outright under `-W error`, which is how the test suite runs.

`tests/test_clustering` on `main` with 0.6.5 installed: **254 failed**, 32 passed. With this change: **291 passed**.

`cluster_counts` does not exist before 0.6.5, so the floor has to move with the rename rather than merely allowing the new version — the two changes are coupled and cannot land separately.

## Why this isn't already in 8.0.0

#755 carried this exact change. While unblocking its lint I retargeted its base onto `ci/pin-ruff-version`; that branch merged into `main` first, so #755 then merged into an already-merged base. GitHub reports it as merged, but the change never reached `main` — 8.0.0 shipped without it. This re-lands it directly on `main`.

## Change

- `transform_accessor.py` — `cluster_weights` → `cluster_counts`
- `pyproject.toml` — `full`: `>= 0.6.1` → `>= 0.6.5`; `dev`: `==0.6.1` → `==0.6.5`

## Release

Typed `fix:`, so release-please will cut **8.0.1** from it (`release-type: simple`, no custom bump rules in `.release-please-config.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)