### PR TITLE
feat: add transform.fix_invest_decisions() and statistics.invested

### DIFF
--- a/docs/notebooks/index.md
+++ b/docs/notebooks/index.md
@@ -66,7 +66,7 @@ Learn flixopt through practical examples organized by topic. Each notebook inclu
 | `PiecewiseConversion`, part-load efficiency | Piecewise Conversion |
 | `PiecewiseEffects`, economies of scale | Piecewise Effects |
 | Periods, scenarios, weights | Scenarios |
-| `transform.resample()`, `fix_sizes()` | Aggregation |
+| `transform.resample()`, `fix_sizes()`, `fix_invest_decisions()` | Aggregation |
 | `optimize.rolling_horizon()` | Rolling Horizon |
 | `transform.cluster()`, typical periods | Clustering |
 | `cluster_mode`, inter-cluster storage | Storage Modes |

--- a/docs/user-guide/results/index.md
+++ b/docs/user-guide/results/index.md
@@ -433,6 +433,21 @@ diff = comp.diff()
 print(f"Cost difference: {diff['costs'].sel(case='Two-Stage').item():.0f} €")
 ```
 
+!!! tip "Fixing the decision instead of the size"
+
+    `fix_sizes()` carries the sizes over as constants, so the dispatch stage cannot react
+    when the full resolution has a higher peak than the aggregated sizing run - it becomes
+    infeasible. `fix_invest_decisions()` carries over only *what gets built* and leaves the
+    sizes free, so the second stage can resize:
+
+    ```python
+    fs_dispatch = flow_system.transform.fix_invest_decisions(fs_sizing.statistics.invested)
+    fs_dispatch.optimize(solver)
+    ```
+
+    Elements whose investment was mandatory have no decision to carry over and are left
+    untouched.
+
 ## Next Steps
 
 - [Plotting Results](../results-plotting.md) - Detailed plotting documentation

--- a/flixopt/statistics_accessor.py
+++ b/flixopt/statistics_accessor.py
@@ -461,6 +461,7 @@ class StatisticsAccessor:
         self._flow_sizes: xr.Dataset | None = None
         self._storage_sizes: xr.Dataset | None = None
         self._sizes: xr.Dataset | None = None
+        self._invested: xr.Dataset | None = None
         self._charge_states: xr.Dataset | None = None
         self._effect_share_factors: dict[str, dict] | None = None
         self._temporal_effects: xr.Dataset | None = None
@@ -629,6 +630,19 @@ class StatisticsAccessor:
         if self._sizes is None:
             self._sizes = xr.merge([self.flow_sizes, self.storage_sizes])
         return self._sizes
+
+    @property
+    def invested(self) -> xr.Dataset:
+        """Investment decisions (build / do not build) as a Dataset with element labels as variable names.
+
+        Only elements whose investment is a decision appear here. An investment that is
+        mandatory everywhere has no binary and is therefore absent.
+        """
+        self._require_solution()
+        if self._invested is None:
+            invested_vars = self._fs.get_variables_by_category(VariableCategory.INVESTED)
+            self._invested = xr.Dataset({v.rsplit('|', 1)[0]: self._fs.solution[v] for v in invested_vars})
+        return self._invested
 
     @property
     def charge_states(self) -> xr.Dataset:

--- a/flixopt/transform_accessor.py
+++ b/flixopt/transform_accessor.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 
     from .clustering import Clustering
     from .flow_system import FlowSystem
+    from .interface import InvestParameters
 
 logger = logging.getLogger('flixopt')
 
@@ -1055,7 +1056,6 @@ class TransformAccessor:
             >>> fs_fixed.optimize(solver)
         """
         from .flow_system import FlowSystem
-        from .interface import InvestParameters
 
         # Get sizes from solution if not provided
         if sizes is None:
@@ -1089,43 +1089,134 @@ class TransformAccessor:
             base_name = size_var[: -len('|size')] if size_var.endswith('|size') else size_var
             fixed_value = sizes[size_var]
 
-            # A fixed size of 0 means "do not invest", every other size means "invest".
-            # A size of 0 also bounds the invested binary to 0, so the periods that do not
-            # build are not charged the flat effects_of_investment.
-            mandatory = (fixed_value != 0).astype(int)
-
-            found = False
-            for flow in new_fs.flows.values():
-                if flow.label_full == base_name and isinstance(flow.size, InvestParameters):
-                    flow.size.fixed_size = fixed_value
-                    flow.size.mandatory = mandatory
-                    found = True
-                    modified = True
-                    logger.debug(f'Fixed size of {base_name} to {fixed_value} (mandatory={mandatory})')
-                    break
-
-            if not found:
-                for component in new_fs.components.values():
-                    if hasattr(component, 'capacity_in_flow_hours'):
-                        if component.label == base_name and isinstance(
-                            component.capacity_in_flow_hours, InvestParameters
-                        ):
-                            component.capacity_in_flow_hours.fixed_size = fixed_value
-                            component.capacity_in_flow_hours.mandatory = mandatory
-                            found = True
-                            modified = True
-                            logger.debug(f'Fixed size of {base_name} to {fixed_value} (mandatory={mandatory})')
-                            break
-
-            if not found:
+            invest_parameters = self._invest_parameters_of(new_fs, base_name)
+            if invest_parameters is None:
                 logger.warning(
                     f'Size variable "{base_name}" not found as InvestParameters in FlowSystem. '
                     f'It may be a fixed-size component or the name may not match.'
                 )
+                continue
+
+            # A fixed size of 0 means "do not invest", every other size means "invest".
+            # A size of 0 also bounds the invested binary to 0, so the periods that do not
+            # build are not charged the flat effects_of_investment.
+            mandatory = (fixed_value != 0).astype(int)
+            invest_parameters.fixed_size = fixed_value
+            invest_parameters.mandatory = mandatory
+            modified = True
+            logger.debug(f'Fixed size of {base_name} to {fixed_value} (mandatory={mandatory})')
 
         # from_dataset() restores the stage-1 solution; drop it so the returned system
         # is an unsolved dispatch problem (as documented) and re-transforms cleanly
         # with the sizes we just assigned on the next optimize().
+        if modified:
+            new_fs.reset()
+
+        return new_fs
+
+    @staticmethod
+    def _invest_parameters_of(flow_system: FlowSystem, label: str) -> InvestParameters | None:
+        """Return the InvestParameters of the flow or storage capacity called ``label``."""
+        from .interface import InvestParameters
+
+        flow = flow_system.flows.get(label)
+        if flow is not None and isinstance(flow.size, InvestParameters):
+            return flow.size
+
+        component = flow_system.components.get(label)
+        if component is not None and isinstance(getattr(component, 'capacity_in_flow_hours', None), InvestParameters):
+            return component.capacity_in_flow_hours
+
+        return None
+
+    def fix_invest_decisions(
+        self,
+        decisions: xr.Dataset | dict[str, bool] | None = None,
+    ) -> FlowSystem:
+        """
+        Create a new FlowSystem with the investment decisions fixed, but the sizes free.
+
+        This is the counterpart to :meth:`fix_sizes` for two-stage workflows where only the
+        combinatorics should be carried over:
+
+        1. Solve a sizing problem (possibly resampled for speed)
+        2. Fix what gets built and re-optimize the sizes at full resolution
+
+        Where an element was built, the investment becomes mandatory and its size stays a
+        decision variable between ``minimum_size`` and ``maximum_size``. Where it was not
+        built, the size is capped at 0, which also rules the investment out - so its fixed
+        effects_of_investment are not charged. Unlike :meth:`fix_sizes`, the dispatch stage
+        can still resize, which keeps it feasible when the full resolution has a higher
+        peak than the aggregated sizing run.
+
+        Args:
+            decisions: The investment decisions to fix. Can be:
+                - None: Uses the decisions from this FlowSystem's solution (must be solved)
+                - xr.Dataset: Dataset with invested variables (e.g., from statistics.invested)
+                - dict: Mapping of element names to decisions (e.g., {'Boiler(Q_fu)': True})
+                Decisions with period/scenario dimensions are preserved, fixing each
+                period/scenario on its own. Elements that are absent are left untouched -
+                an investment that was mandatory in the sizing run has no decision to fix.
+
+        Returns:
+            FlowSystem: New FlowSystem with fixed investment decisions (no solution).
+
+        Raises:
+            ValueError: If no decisions are provided and the FlowSystem has no solution.
+
+        Examples:
+            Size on aggregated data, then re-optimize the sizes at full resolution:
+
+            >>> fs_sizing = flow_system.transform.resample('4h')
+            >>> fs_sizing.optimize(solver)
+            >>>
+            >>> fs_dispatch = flow_system.transform.fix_invest_decisions(fs_sizing.stats.invested)
+            >>> fs_dispatch.optimize(solver)
+
+            Using a dict:
+
+            >>> fs_fixed = flow_system.transform.fix_invest_decisions({'Boiler(Q_fu)': True, 'Storage': False})
+            >>> fs_fixed.optimize(solver)
+        """
+        from .flow_system import FlowSystem
+
+        if decisions is None:
+            if self._fs.solution is None:
+                raise ValueError(
+                    'No decisions provided and FlowSystem has no solution. '
+                    'Either provide decisions or optimize the FlowSystem first.'
+                )
+            decisions = self._fs.stats.invested
+
+        if isinstance(decisions, dict):
+            decisions = xr.Dataset({k: xr.DataArray(v) for k, v in decisions.items()})
+
+        if not self._fs.connected_and_transformed:
+            self._fs.connect_and_transform()
+
+        new_fs = FlowSystem.from_dataset(self._fs.to_dataset())
+
+        modified = False
+        for decision_var in decisions.data_vars:
+            base_name = decision_var[: -len('|invested')] if decision_var.endswith('|invested') else decision_var
+            built = (decisions[decision_var] != 0).astype(int)
+
+            invest_parameters = self._invest_parameters_of(new_fs, base_name)
+            if invest_parameters is None:
+                logger.warning(
+                    f'Invested variable "{base_name}" not found as InvestParameters in FlowSystem. '
+                    f'It may be a fixed-size component or the name may not match.'
+                )
+                continue
+
+            invest_parameters.mandatory = built
+            if invest_parameters.fixed_size is not None:
+                invest_parameters.fixed_size = xr.where(built, invest_parameters.fixed_size, 0)
+            else:
+                invest_parameters.maximum_size = xr.where(built, invest_parameters.maximum_size, 0)
+            modified = True
+            logger.debug(f'Fixed investment decision of {base_name} to {built}')
+
         if modified:
             new_fs.reset()
 

--- a/tests/test_math/test_multi_period.py
+++ b/tests/test_math/test_multi_period.py
@@ -484,6 +484,131 @@ class TestMultiPeriod:
         assert_allclose(fs_dispatch.solution['Boiler(heat)|size'].item(), 0.0, atol=1e-6)
         assert_allclose(fs_dispatch.solution['objective'].item(), 160.0, rtol=1e-5)
 
+    def test_fix_sizes_and_decisions_reach_storage_capacity(self, optimize):
+        """Proves: both fix_sizes() and fix_invest_decisions() reach a storage capacity
+        investment, not just flow sizes.
+
+        4 ts, Demand=[0, 30, 0, 30], gas @[1, 20, 1, 20]. A Battery charges cheap and
+        discharges at the peak. Capacity invest: 5€ fixed + 1€/kWh.
+        Optimal: capacity 30, fuel 60 @1 = 60, invest 5 + 30 -> objective 95.
+
+        Sensitivity: storage investments live in Storage.capacity_in_flow_hours, not in
+        Flow.size, so a lookup that only scans flows would silently leave the capacity a
+        free variable - and fix_invest_decisions() would not make it mandatory.
+        """
+        fs = make_flow_system(n_timesteps=4)
+        fs.add_elements(
+            fx.Bus('Heat'),
+            fx.Bus('Gas'),
+            fx.Effect('costs', '€', is_standard=True, is_objective=True),
+            fx.Sink(
+                'Demand',
+                inputs=[
+                    fx.Flow(
+                        'heat',
+                        bus='Heat',
+                        size=1,
+                        fixed_relative_profile=np.array([0.0, 30.0, 0.0, 30.0]),
+                    )
+                ],
+            ),
+            fx.Source(
+                'GasSrc',
+                outputs=[fx.Flow('gas', bus='Gas', effects_per_flow_hour=np.array([1.0, 20.0, 1.0, 20.0]))],
+            ),
+            fx.linear_converters.Boiler(
+                'Boiler',
+                thermal_efficiency=1.0,
+                fuel_flow=fx.Flow('fuel', bus='Gas'),
+                thermal_flow=fx.Flow('heat', bus='Heat', size=100),
+            ),
+            fx.Storage(
+                'Battery',
+                charging=fx.Flow('in', bus='Heat', size=100),
+                discharging=fx.Flow('out', bus='Heat', size=100),
+                capacity_in_flow_hours=fx.InvestParameters(
+                    maximum_size=100,
+                    effects_of_investment=5,
+                    effects_of_investment_per_size=1,
+                ),
+                initial_charge_state=0,
+            ),
+        )
+        fs_sizing = optimize(fs)
+        assert_allclose(fs_sizing.solution['Battery|size'].item(), 30.0, rtol=1e-5)
+        assert_allclose(fs_sizing.solution['objective'].item(), 95.0, rtol=1e-5)
+        assert list(fs_sizing.stats.invested.data_vars) == ['Battery']
+
+        fs_fixed = fs.transform.fix_sizes(fs_sizing.stats.sizes)
+        assert fs_fixed.components['Battery'].capacity_in_flow_hours.fixed_size == 30.0
+        fs_fixed.optimize(_SOLVER)
+        assert_allclose(fs_fixed.solution['Battery|size'].item(), 30.0, rtol=1e-5)
+        assert_allclose(fs_fixed.solution['objective'].item(), 95.0, rtol=1e-5)
+
+        fs_decided = fs.transform.fix_invest_decisions(fs_sizing.stats.invested)
+        assert fs_decided.components['Battery'].capacity_in_flow_hours.fixed_size is None
+        fs_decided.optimize(_SOLVER)
+        assert_allclose(fs_decided.solution['Battery|size'].item(), 30.0, rtol=1e-5)
+        assert_allclose(fs_decided.solution['objective'].item(), 95.0, rtol=1e-5)
+
+    def test_fix_invest_decisions_forbids_unbuilt_storage(self, optimize):
+        """Proves: an unbuilt storage capacity is capped at 0 by fix_invest_decisions(),
+        so its fixed effects_of_investment are not charged.
+
+        Same system, but the capacity investment costs a prohibitive 5000€. Not building
+        and buying at the peak is cheaper: 60 @20 = 1200.
+
+        Sensitivity: leaving the capacity free would let the dispatch stage build the
+        battery after all; making it mandatory would charge the 5000€.
+        """
+        fs = make_flow_system(n_timesteps=4)
+        fs.add_elements(
+            fx.Bus('Heat'),
+            fx.Bus('Gas'),
+            fx.Effect('costs', '€', is_standard=True, is_objective=True),
+            fx.Sink(
+                'Demand',
+                inputs=[
+                    fx.Flow(
+                        'heat',
+                        bus='Heat',
+                        size=1,
+                        fixed_relative_profile=np.array([0.0, 30.0, 0.0, 30.0]),
+                    )
+                ],
+            ),
+            fx.Source(
+                'GasSrc',
+                outputs=[fx.Flow('gas', bus='Gas', effects_per_flow_hour=np.array([1.0, 20.0, 1.0, 20.0]))],
+            ),
+            fx.linear_converters.Boiler(
+                'Boiler',
+                thermal_efficiency=1.0,
+                fuel_flow=fx.Flow('fuel', bus='Gas'),
+                thermal_flow=fx.Flow('heat', bus='Heat', size=100),
+            ),
+            fx.Storage(
+                'Battery',
+                charging=fx.Flow('in', bus='Heat', size=100),
+                discharging=fx.Flow('out', bus='Heat', size=100),
+                capacity_in_flow_hours=fx.InvestParameters(
+                    maximum_size=100,
+                    effects_of_investment=5000,
+                    effects_of_investment_per_size=1,
+                ),
+                initial_charge_state=0,
+            ),
+        )
+        fs_sizing = optimize(fs)
+        assert_allclose(fs_sizing.solution['Battery|size'].item(), 0.0, atol=1e-6)
+        assert_allclose(fs_sizing.solution['objective'].item(), 1200.0, rtol=1e-5)
+
+        fs_decided = fs.transform.fix_invest_decisions(fs_sizing.stats.invested)
+        assert fs_decided.components['Battery'].capacity_in_flow_hours.maximum_size == 0
+        fs_decided.optimize(_SOLVER)
+        assert_allclose(fs_decided.solution['Battery|size'].item(), 0.0, atol=1e-6)
+        assert_allclose(fs_decided.solution['objective'].item(), 1200.0, rtol=1e-5)
+
     def test_fix_invest_decisions_keeps_sizes_free(self, optimize):
         """Proves: transform.fix_invest_decisions() carries over what gets built, but lets
         the size re-optimize - so a higher peak at full resolution is absorbed by resizing.

--- a/tests/test_math/test_multi_period.py
+++ b/tests/test_math/test_multi_period.py
@@ -484,6 +484,121 @@ class TestMultiPeriod:
         assert_allclose(fs_dispatch.solution['Boiler(heat)|size'].item(), 0.0, atol=1e-6)
         assert_allclose(fs_dispatch.solution['objective'].item(), 160.0, rtol=1e-5)
 
+    def test_fix_invest_decisions_keeps_sizes_free(self, optimize):
+        """Proves: transform.fix_invest_decisions() carries over what gets built, but lets
+        the size re-optimize - so a higher peak at full resolution is absorbed by resizing.
+
+        periods=[2020, 2021], weights [1, 1], 3 ts each. Demand is 0 in 2020 and peaks in
+        2021. Boiler: 100€ fixed invest, 1€ per size, fuel @1€.
+
+        Stage 1 sizes against a peak of 90 and builds in 2021 only: invested [0, 1].
+        Stage 2 keeps that decision but faces the true peak of 140, so the size grows to
+        140: 100 + 140 + 160 fuel = 400.
+
+        Sensitivity: fix_sizes() pins the size at 90, which makes the 140 peak infeasible.
+        If the decision were not carried over at all, 2020 could build as well.
+        """
+
+        def build(peak):
+            fs = make_multi_period_flow_system(n_timesteps=3, periods=[2020, 2021], weight_of_last_period=1)
+            demand = xr.DataArray(
+                np.array([[0, 0, 0], [10, peak, 10]], dtype=float),
+                coords={'period': [2020, 2021], 'time': fs.timesteps},
+                dims=['period', 'time'],
+            )
+            fs.add_elements(
+                fx.Bus('Heat'),
+                fx.Bus('Gas'),
+                fx.Effect('costs', '€', is_standard=True, is_objective=True),
+                fx.Sink('Demand', inputs=[fx.Flow('heat', bus='Heat', size=1, fixed_relative_profile=demand)]),
+                fx.Source('GasSrc', outputs=[fx.Flow('gas', bus='Gas', effects_per_flow_hour=1)]),
+                fx.linear_converters.Boiler(
+                    'Boiler',
+                    thermal_efficiency=1.0,
+                    fuel_flow=fx.Flow('fuel', bus='Gas'),
+                    thermal_flow=fx.Flow(
+                        'heat',
+                        bus='Heat',
+                        size=fx.InvestParameters(
+                            maximum_size=200,
+                            effects_of_investment=100,
+                            effects_of_investment_per_size=1,
+                        ),
+                    ),
+                ),
+            )
+            return fs
+
+        fs_sizing = optimize(build(peak=90))
+        assert_allclose(fs_sizing.solution['Boiler(heat)|invested'].values, [0.0, 1.0], atol=1e-6)
+        assert_allclose(fs_sizing.solution['Boiler(heat)|size'].values, [0.0, 90.0], rtol=1e-5)
+
+        fs_dispatch = build(peak=140).transform.fix_invest_decisions(fs_sizing.stats.invested)
+        fs_dispatch.optimize(_SOLVER)
+        assert_allclose(fs_dispatch.solution['Boiler(heat)|invested'].values, [0.0, 1.0], atol=1e-6)
+        assert_allclose(fs_dispatch.solution['Boiler(heat)|size'].values, [0.0, 140.0], rtol=1e-5)
+        assert_allclose(fs_dispatch.solution['objective'].item(), 400.0, rtol=1e-5)
+
+    def test_fix_invest_decisions_leaves_mandatory_elements_untouched(self, optimize):
+        """Proves: transform.fix_invest_decisions() does not forbid an investment that was
+        mandatory in the sizing run and therefore has no decision to carry over.
+
+        3 ts, Demand=[10, 10, 10]. MustBoiler is mandatory (10€ invest + 1€ per size),
+        OptBoiler is optional but prohibitively expensive (10000€) and stays unbuilt.
+        A mandatory investment has no invested binary, so it is absent from
+        statistics.invested. MustBoiler serves everything: 10 + 10 periodic + 30 fuel = 50.
+
+        Sensitivity: reading a missing entry as "not built" would cap MustBoiler at size 0,
+        leaving the demand unservable.
+        """
+        fs = make_flow_system(n_timesteps=3)
+        demand = xr.DataArray(np.array([10, 10, 10], dtype=float), coords={'time': fs.timesteps}, dims=['time'])
+        fs.add_elements(
+            fx.Bus('Heat'),
+            fx.Bus('Gas'),
+            fx.Effect('costs', '€', is_standard=True, is_objective=True),
+            fx.Sink('Demand', inputs=[fx.Flow('heat', bus='Heat', size=1, fixed_relative_profile=demand)]),
+            fx.Source('GasSrc', outputs=[fx.Flow('gas', bus='Gas', effects_per_flow_hour=1)]),
+            fx.linear_converters.Boiler(
+                'MustBoiler',
+                thermal_efficiency=1.0,
+                fuel_flow=fx.Flow('fuel', bus='Gas'),
+                thermal_flow=fx.Flow(
+                    'heat',
+                    bus='Heat',
+                    size=fx.InvestParameters(
+                        maximum_size=200,
+                        mandatory=True,
+                        effects_of_investment=10,
+                        effects_of_investment_per_size=1,
+                    ),
+                ),
+            ),
+            fx.linear_converters.Boiler(
+                'OptBoiler',
+                thermal_efficiency=1.0,
+                fuel_flow=fx.Flow('fuel', bus='Gas'),
+                thermal_flow=fx.Flow(
+                    'heat',
+                    bus='Heat',
+                    size=fx.InvestParameters(
+                        maximum_size=200,
+                        effects_of_investment=10000,
+                        effects_of_investment_per_size=1,
+                    ),
+                ),
+            ),
+        )
+        fs_sizing = optimize(fs)
+        # A mandatory investment has no decision, so only the optional one shows up
+        assert list(fs_sizing.stats.invested.data_vars) == ['OptBoiler(heat)']
+
+        fs_dispatch = fs.transform.fix_invest_decisions(fs_sizing.stats.invested)
+        fs_dispatch.optimize(_SOLVER)
+        assert_allclose(fs_dispatch.solution['MustBoiler(heat)|size'].item(), 10.0, rtol=1e-5)
+        assert_allclose(fs_dispatch.solution['OptBoiler(heat)|size'].item(), 0.0, atol=1e-6)
+        assert_allclose(fs_dispatch.solution['objective'].item(), 50.0, rtol=1e-5)
+
     def test_fix_sizes_enforces_investment_in_nonzero_periods(self, optimize):
         """Proves: transform.fix_sizes() forces the investment in every period with a
         non-zero size, even when skipping it would be cheaper.


### PR DESCRIPTION
> **Stacked on #772** — review that one first; this PR's diff is only the last commit.

## Why

`fix_sizes()` carries the sizes over as constants. That is right for a pure dispatch run, but it is brittle in the aggregate→full-resolution workflow: if the true peak is higher than the aggregated sizing run saw, the fixed size cannot serve it and stage 2 is simply **infeasible**.

```
stage 1 (peak 90)   invested [0, 1]   size [0, 90]
stage 2 (peak 140)  fix_sizes()            -> infeasible
                    fix_invest_decisions() -> size [0, 140], objective 400
```

Often what you actually want to carry over is the *combinatorics* — which assets get built — while letting the continuous part re-optimize against the finer data.

## What

`transform.fix_invest_decisions(decisions=None)`, the counterpart to `fix_sizes()`:

- **built** → the investment becomes mandatory, the size stays a decision variable between `minimum_size` and `maximum_size`.
- **not built** → the size is capped at 0, which also rules the investment out, so its fixed `effects_of_investment` are not charged.

Both halves fall straight out of the primitives added in #772 (`mandatory` per period/scenario, and `invested ≤ (max_or_fixed_size ≠ 0)`) — no new modelling machinery:

```python
invest_parameters.mandatory = built
invest_parameters.maximum_size = xr.where(built, invest_parameters.maximum_size, 0)
```

Also in this PR:

- **`statistics.invested`** — the investment decisions as a Dataset, mirroring `statistics.sizes`. `VariableCategory.INVESTED` already existed but had no accessor; this is what `fix_invest_decisions()` reads by default.
- The flow/storage-capacity element lookup shared with `fix_sizes()` moved into `_invest_parameters_of()` instead of being duplicated.

### The one trap

An investment that was **mandatory** in the sizing run has no `invested` binary, so it never appears in `statistics.invested`. A missing entry therefore means *"leave it alone"*, never *"not built"* — otherwise a mandatory investment would be silently capped at size 0 and the model left infeasible. Covered by its own test.

## Tests

- `test_fix_invest_decisions_keeps_sizes_free` — decision `[0, 1]` carried over, size re-optimized 90 → 140, objective 400.
- `test_fix_invest_decisions_leaves_mandatory_elements_untouched` — asserts a mandatory element is absent from `statistics.invested` and still sized freely afterwards.
- `test_fix_sizes_and_decisions_reach_storage_capacity` / `test_fix_invest_decisions_forbids_unbuilt_storage` — storage coverage for **both** transforms.

### Storage coverage

`Flow.size` and `Storage.capacity_in_flow_hours` are the only two attributes that can hold `InvestParameters`. Both transforms handle both, built and not built — verified and now tested, since nothing in the suite exercised the storage path and this PR replaces the old `component.label` scan with a dict lookup:

| | `fix_sizes` | `fix_invest_decisions` |
|---|---|---|
| storage built (cap 30) | `fixed_size=30, mandatory=1` → 30, obj 95 | `mandatory=1, max=100` → resized to 30, obj 95 |
| storage not built | `fixed_size=0` → 0, obj 1200 | `max=0` → 0, obj 1200 |

`tests/test_math` green (407 passed); full suite running.

## Docs

Two-stage section in `docs/user-guide/results/index.md` gains a tip contrasting the two methods, and the notebooks index lists the new method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C61ickLcfTBDHkAtDpvktP


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a way to carry investment decisions between sizing and dispatch runs while allowing sizes to be optimized again.
  - Investment decisions are now available through system statistics.
  - Mandatory investments remain unaffected.

- **Documentation**
  - Added guidance and an example for fixing investment decisions instead of sizes.
  - Documented the new investment-decision transformation in the key concepts reference.

- **Bug Fixes**
  - Improved investment handling for storage capacity and multi-period investments, including more reliable behavior when elements are built or unbuilt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->